### PR TITLE
refactor: change generic type names more descriptively

### DIFF
--- a/src/decorators/aop-decorator-classes.ts
+++ b/src/decorators/aop-decorator-classes.ts
@@ -18,16 +18,12 @@ import { addMetadata } from '../utils';
 /**
  * Constructor signature for AOP decorator classes.
  *
- * @template O - Options type
- *
  * @internal
  */
-type AOPDecoratorConstructor<O extends AOPOptions> = new () => AOPDecorator<O>;
+type AOPDecoratorConstructor<Options extends AOPOptions> = new () => AOPDecorator<Options>;
 
 /**
  * Provides the foundation for creating custom AOP decorators.
- *
- * @template O - Options type
  *
  * @example
  * ```typescript
@@ -48,14 +44,15 @@ type AOPDecoratorConstructor<O extends AOPOptions> = new () => AOPDecorator<O>;
  * ```
  */
 @Injectable()
-export abstract class AOPDecorator<O extends AOPOptions = AOPOptions> implements IAOPDecorator<O> {
+export abstract class AOPDecorator<Options extends AOPOptions = AOPOptions>
+  implements IAOPDecorator<Options>
+{
   /**
    * Creates a method decorator that applies around advice to the target method.
    *
    * The around advice has full control over method execution and can modify
    * parameters, conditionally execute the method, or return a different result.
    *
-   * @template O - Options type
    * @param options - Configuration options for the decorator
    * @returns A method decorator function
    *
@@ -69,9 +66,9 @@ export abstract class AOPDecorator<O extends AOPOptions = AOPOptions> implements
    * }
    * ```
    */
-  static around<O extends AOPOptions = AOPOptions>(
-    this: AOPDecoratorConstructor<O> & AroundAOP<O>,
-    options: O = {} as O,
+  static around<Options extends AOPOptions = AOPOptions>(
+    this: AOPDecoratorConstructor<Options> & AroundAOP<Options>,
+    options: Options = {} as Options,
   ): MethodDecorator {
     return (target: object, propertyKey: string | symbol, _descriptor: PropertyDescriptor) => {
       const decoratorClass = this.name;
@@ -90,7 +87,6 @@ export abstract class AOPDecorator<O extends AOPOptions = AOPOptions> implements
    *
    * The before advice executes before the method runs.
    *
-   * @template O - Options type
    * @param options - Configuration options for the decorator
    * @returns A method decorator function
    *
@@ -104,9 +100,9 @@ export abstract class AOPDecorator<O extends AOPOptions = AOPOptions> implements
    * }
    * ```
    */
-  static before<O extends AOPOptions = AOPOptions>(
-    this: AOPDecoratorConstructor<O> & BeforeAOP<O>,
-    options: O = {} as O,
+  static before<Options extends AOPOptions = AOPOptions>(
+    this: AOPDecoratorConstructor<Options> & BeforeAOP<Options>,
+    options: Options = {} as Options,
   ): MethodDecorator {
     return (target: object, propertyKey: string | symbol, _descriptor: PropertyDescriptor) => {
       const decoratorClass = this.name;
@@ -126,7 +122,6 @@ export abstract class AOPDecorator<O extends AOPOptions = AOPOptions> implements
    * The after advice executes after the method completes, regardless of whether
    * it succeeded or threw an exception.
    *
-   * @template O - Options type extending AOPOptions
    * @param options - Configuration options for the decorator
    * @returns A method decorator function
    *
@@ -140,9 +135,9 @@ export abstract class AOPDecorator<O extends AOPOptions = AOPOptions> implements
    * }
    * ```
    */
-  static after<O extends AOPOptions = AOPOptions>(
-    this: AOPDecoratorConstructor<O> & AfterAOP<O>,
-    options: O = {} as O,
+  static after<Options extends AOPOptions = AOPOptions>(
+    this: AOPDecoratorConstructor<Options> & AfterAOP<Options>,
+    options: Options = {} as Options,
   ): MethodDecorator {
     return (target: object, propertyKey: string | symbol, _descriptor: PropertyDescriptor) => {
       const decoratorClass = this.name;
@@ -162,7 +157,6 @@ export abstract class AOPDecorator<O extends AOPOptions = AOPOptions> implements
    * The after-returning advice executes only when the method completes successfully
    * and provides access to the return value for post-processing.
    *
-   * @template O - Options type
    * @param options - Configuration options for the decorator
    * @returns A method decorator function
    *
@@ -176,9 +170,9 @@ export abstract class AOPDecorator<O extends AOPOptions = AOPOptions> implements
    * }
    * ```
    */
-  static afterReturning<O extends AOPOptions = AOPOptions>(
-    this: AOPDecoratorConstructor<O> & AfterReturningAOP<O, any>,
-    options: O = {} as O,
+  static afterReturning<Options extends AOPOptions = AOPOptions>(
+    this: AOPDecoratorConstructor<Options> & AfterReturningAOP<Options, any>,
+    options: Options = {} as Options,
   ): MethodDecorator {
     return (target: object, propertyKey: string | symbol, _descriptor: PropertyDescriptor) => {
       const decoratorClass = this.name;
@@ -198,7 +192,6 @@ export abstract class AOPDecorator<O extends AOPOptions = AOPOptions> implements
    * The after-throwing advice executes only when the method throws an exception
    * and provides access to the error for logging, recovery, or re-throwing.
    *
-   * @template O - Options type
    * @param options - Configuration options for the decorator
    * @returns A method decorator function
    *
@@ -212,9 +205,9 @@ export abstract class AOPDecorator<O extends AOPOptions = AOPOptions> implements
    * }
    * ```
    */
-  static afterThrowing<O extends AOPOptions = AOPOptions>(
-    this: AOPDecoratorConstructor<O> & AfterThrowingAOP<O, unknown>,
-    options: O = {} as O,
+  static afterThrowing<Options extends AOPOptions = AOPOptions>(
+    this: AOPDecoratorConstructor<Options> & AfterThrowingAOP<Options, unknown>,
+    options: Options = {} as Options,
   ): MethodDecorator {
     return (target: object, propertyKey: string | symbol, _descriptor: PropertyDescriptor) => {
       const decoratorClass = this.name;
@@ -239,7 +232,7 @@ export abstract class AOPDecorator<O extends AOPOptions = AOPOptions> implements
    * @param context - Context containing the original method and options
    * @returns A wrapped method function that will be executed
    */
-  around?(context: UnitAOPContext<O>): AOPMethod<any>;
+  around?(context: UnitAOPContext<Options>): AOPMethod<any>;
 
   /**
    * Before decorator method (optional implementation)
@@ -249,7 +242,7 @@ export abstract class AOPDecorator<O extends AOPOptions = AOPOptions> implements
    * @param context - Context containing the original method and options
    * @returns A callback function executed before the method
    */
-  before?(context: UnitAOPContext<O>): AOPMethod<void>;
+  before?(context: UnitAOPContext<Options>): AOPMethod<void>;
 
   /**
    * After decorator method (optional implementation)
@@ -259,7 +252,7 @@ export abstract class AOPDecorator<O extends AOPOptions = AOPOptions> implements
    * @param context - Context containing the original method and options
    * @returns A callback function executed after the method
    */
-  after?(context: UnitAOPContext<O>): AOPMethod<void>;
+  after?(context: UnitAOPContext<Options>): AOPMethod<void>;
 
   /**
    * AfterReturning decorator method (optional implementation)
@@ -270,7 +263,7 @@ export abstract class AOPDecorator<O extends AOPOptions = AOPOptions> implements
    * @param context - Context containing the method, options, and result
    * @returns A callback function executed after successful method completion
    */
-  afterReturning?(context: ResultAOPContext<O>): AOPMethod<void>;
+  afterReturning?(context: ResultAOPContext<Options>): AOPMethod<void>;
 
   /**
    * AfterThrowing decorator method (optional implementation)
@@ -280,5 +273,5 @@ export abstract class AOPDecorator<O extends AOPOptions = AOPOptions> implements
    * @param context - Context containing the method, options, and error
    * @returns A callback function executed when an exception occurs
    */
-  afterThrowing?(context: ErrorAOPContext<O>): AOPMethod<void>;
+  afterThrowing?(context: ErrorAOPContext<Options>): AOPMethod<void>;
 }

--- a/src/interfaces/aop-decorator.interface.ts
+++ b/src/interfaces/aop-decorator.interface.ts
@@ -10,17 +10,16 @@ import type { AOPType } from './aop.interface';
 /**
  * Base interface for all AOP decorators, providing optional implementations
  * for various AOP advice types (around, before, after, etc.).
- *
- * @template O - Options type
- * @template T - Method return type (default: `any`)
- * @template E - Error type (default: `unknown`)
  */
-export interface IAOPDecorator<O extends AOPOptions = AOPOptions, T = any, E = unknown>
-  extends Partial<AroundAOP<O, T>>,
-    Partial<BeforeAOP<O>>,
-    Partial<AfterAOP<O>>,
-    Partial<AfterReturningAOP<O, T>>,
-    Partial<AfterThrowingAOP<O, E>> {}
+export interface IAOPDecorator<
+  Options extends AOPOptions = AOPOptions,
+  ReturnType = any,
+  ErrorType = unknown,
+> extends Partial<AroundAOP<Options, ReturnType>>,
+    Partial<BeforeAOP<Options>>,
+    Partial<AfterAOP<Options>>,
+    Partial<AfterReturningAOP<Options, ReturnType>>,
+    Partial<AfterThrowingAOP<Options, ErrorType>> {}
 
 /**
  * Options passed to AOP decorators.

--- a/src/interfaces/aop-execution.interface.ts
+++ b/src/interfaces/aop-execution.interface.ts
@@ -6,46 +6,39 @@ import type { AOPMethod, ErrorAOPContext, ResultAOPContext, UnitAOPContext } fro
  *
  * Allows complete control over method invocation, including the ability to modify
  * parameters, skip execution, or alter the return value.
- *
- * @template O - Options type
- * @template T - Method return type (default: `any`)
  */
-export interface AroundAOP<O extends AOPOptions = AOPOptions, T = any> {
+export interface AroundAOP<Options extends AOPOptions = AOPOptions, ReturnType = any> {
   /**
    * Around decorator method
    *
    * See {@link AOPDecorator.around} for details.
    */
-  around(context: UnitAOPContext<O>): AOPMethod<T>;
+  around(context: UnitAOPContext<Options>): AOPMethod<ReturnType>;
 }
 
 /**
  * Contract for before advice, which executes before the target method.
- *
- * @template O - Options type
  */
-export interface BeforeAOP<O extends AOPOptions = AOPOptions> {
+export interface BeforeAOP<Options extends AOPOptions = AOPOptions> {
   /**
    * Before decorator method
    *
    * See {@link AOPDecorator.before} for details.
    */
-  before(context: UnitAOPContext<O>): AOPMethod<void>;
+  before(context: UnitAOPContext<Options>): AOPMethod<void>;
 }
 
 /**
  * Contract for after advice, which executes after the target method,
  * regardless of whether it completed successfully or threw an exception.
- *
- * @template O - Options type
  */
-export interface AfterAOP<O extends AOPOptions = AOPOptions> {
+export interface AfterAOP<Options extends AOPOptions = AOPOptions> {
   /**
    * After decorator method
    *
    * See {@link AOPDecorator.after} for details.
    */
-  after(context: UnitAOPContext<O>): AOPMethod<void>;
+  after(context: UnitAOPContext<Options>): AOPMethod<void>;
 }
 
 /**
@@ -53,31 +46,25 @@ export interface AfterAOP<O extends AOPOptions = AOPOptions> {
  * the target method completes successfully without throwing an exception.
  *
  * Provides access to the method's return value.
- *
- * @template O - Options type
- * @template T - Method return type (default: `any`)
  */
-export interface AfterReturningAOP<O extends AOPOptions = AOPOptions, T = any> {
+export interface AfterReturningAOP<Options extends AOPOptions = AOPOptions, ReturnType = any> {
   /**
    * AfterReturning decorator method
    *
    * See {@link AOPDecorator.afterReturning} for details.
    */
-  afterReturning(context: ResultAOPContext<O, T>): AOPMethod<void>;
+  afterReturning(context: ResultAOPContext<Options, ReturnType>): AOPMethod<void>;
 }
 
 /**
  * Contract for after-throwing advice, which executes only when
  * the target method throws an exception. Provides access to the thrown error.
- *
- * @template O - Options type
- * @template E - Error type (default: `unknown`)
  */
-export interface AfterThrowingAOP<O extends AOPOptions = AOPOptions, E = unknown> {
+export interface AfterThrowingAOP<Options extends AOPOptions = AOPOptions, ErrorType = unknown> {
   /**
    * AfterThrowing decorator method
    *
    * See {@link AOPDecorator.afterThrowing} for details.
    */
-  afterThrowing(context: ErrorAOPContext<O, E>): AOPMethod<void>;
+  afterThrowing(context: ErrorAOPContext<Options, ErrorType>): AOPMethod<void>;
 }

--- a/src/interfaces/aop.interface.ts
+++ b/src/interfaces/aop.interface.ts
@@ -29,31 +29,25 @@ export type AOPType = (typeof AOP_TYPES)[keyof typeof AOP_TYPES];
 
 /**
  * A method function that can be used in AOP contexts.
- *
- * @template T - The return type of the method (default: `any`)
  */
-export type AOPMethod<T = any> = (...args: any[]) => T;
+export type AOPMethod<ReturnType = any> = (...args: any[]) => ReturnType;
 
 /**
  * Context object passed to AOP decorators.
  *
  * Containing all information needed for method interception and advice execution.
  *
- * @template O - Options type
- * @template T - Method return type (default: `any`)
- * @template E - Error type (default: `unknown`)
- *
  * @internal
  */
-export type AOPContext<O = AOPOptions, T = any, E = unknown> = {
+export type AOPContext<Options = AOPOptions, ReturnType = any, ErrorType = unknown> = {
   /** The original method function being intercepted */
   method: Function;
   /** Configuration options passed to the decorator */
-  options: O;
+  options: Options;
   /** The result returned by the method (available in afterReturning) */
-  result?: T;
+  result?: ReturnType;
   /** The error thrown by the method (available in afterThrowing) */
-  error?: E;
+  error?: ErrorType;
 };
 
 /**
@@ -61,31 +55,23 @@ export type AOPContext<O = AOPOptions, T = any, E = unknown> = {
  * method results or errors.
  *
  * (`before`, `after`, `around` advice)
- *
- * @template O - Options type
  */
-export type UnitAOPContext<O = AOPOptions> = Pick<AOPContext<O>, 'method' | 'options'>;
+export type UnitAOPContext<Options = AOPOptions> = Pick<AOPContext<Options>, 'method' | 'options'>;
 
 /**
  * Context used for `after-returning` advice, providing access to the
  * method's return value along with the standard context information.
- *
- * @template O - Options type
- * @template T - Method return type (default: `any`)
  */
-export type ResultAOPContext<O = AOPOptions, T = any> = Pick<
-  AOPContext<O, T>,
+export type ResultAOPContext<Options = AOPOptions, ReturnType = any> = Pick<
+  AOPContext<Options, ReturnType>,
   'method' | 'options' | 'result'
 >;
 
 /**
  * Context used for `after-throwing` advice, providing access to the
  * exception thrown by the method along with the standard context information.
- *
- * @template O - Options type
- * @template E - Error type (default: `unknown`)
  */
-export type ErrorAOPContext<O = AOPOptions, E = unknown> = Pick<
-  AOPContext<O, unknown, E>,
+export type ErrorAOPContext<Options = AOPOptions, ErrorType = unknown> = Pick<
+  AOPContext<Options, unknown, ErrorType>,
   'method' | 'options' | 'error'
 >;


### PR DESCRIPTION
change generic type names more descriptively and remove JSDoc generic template part
ex. O -> Options, T -> ReturnType, E -> ErrorType

(API documentation will be update in next release)