### PR TITLE
refactor: move discovery module to aop module imports

### DIFF
--- a/src/aop.module.spec.ts
+++ b/src/aop.module.spec.ts
@@ -1,4 +1,3 @@
-import { DiscoveryModule } from '@nestjs/core';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { AOPModule } from './aop.module';
@@ -49,7 +48,6 @@ describe('AOPModule', () => {
 
       expect(dynamicModule).toEqual({
         module: AOPModule,
-        imports: [DiscoveryModule],
         global: true,
       });
     });

--- a/src/aop.module.ts
+++ b/src/aop.module.ts
@@ -10,6 +10,7 @@ import { logger } from './utils';
  * It automatically discovers AOP decorators and applies them to target methods at runtime.
  */
 @Module({
+  imports: [DiscoveryModule],
   providers: [InstanceCollector, MethodProcessor, DecoratorApplier],
 })
 export class AOPModule implements OnModuleInit {
@@ -29,7 +30,6 @@ export class AOPModule implements OnModuleInit {
   static forRoot(): DynamicModule {
     return {
       module: AOPModule,
-      imports: [DiscoveryModule],
       global: true,
     };
   }


### PR DESCRIPTION
- moved `DiscoveryModule` import to AOPModule imports instead of forRoot import