### PR TITLE
refactor: modify JSDoc comments in AOPDecorator

### DIFF
--- a/src/decorators/aop-decorator-classes.ts
+++ b/src/decorators/aop-decorator-classes.ts
@@ -32,10 +32,10 @@ export type AOPDecoratorConstructor<Options extends AOPOptions = AOPOptions> =
  * ```typescript
  * ＠Aspect()
  * export class LoggingAOP extends AOPDecorator {
- *   around({ method, options }: UnitAOPContext) {
+ *   around({ process, method, options }: AroundAOPContext) {
  *    return (...args: any[]) => {
- *      console.log('Around: Before method call', ...args, options);
- *      const result = method.apply(this, args);
+ *      console.log('Around: Before method call', ...args, options, method);
+ *      const result = proceed(...args);
  *      console.log('Around: After method call', result);
  *      return result;
  *    };

--- a/src/services/decorator-applier.service.ts
+++ b/src/services/decorator-applier.service.ts
@@ -127,7 +127,7 @@ export class DecoratorApplier {
     // so that lower order decorators are applied first (outermost in the chain).
     const sortedDecorators = decorators.sort((a, b) => a.order - b.order);
 
-    const decoratorsByType: Record<string, typeof sortedDecorators> = {};
+    const decoratorsByType: Record<string, AOPDecoratorMetadataWithOrder[]> = {};
     for (const decorator of sortedDecorators) {
       const type = decorator.type;
       if (!decoratorsByType[type]) {


### PR DESCRIPTION
- refactor `decoratorsByType` variable type to `Record<string, AOPDecoratorMetadataWithOrder[]>` for better clarity.