### PR TITLE
feature: remove invalidateClassCache method

### DIFF
--- a/src/services/method-processor.cache.spec.ts
+++ b/src/services/method-processor.cache.spec.ts
@@ -103,7 +103,7 @@ describe('MethodProcessor - Cache Functionality', () => {
       expect(stats.hits).toBe(2);
 
       // Invalidate only TestClass1
-      service.invalidateClassCache(TestClass1);
+      (service as any).classCache.delete(TestClass1);
 
       // TestClass1 should miss, TestClass2 should hit
       service.processInstanceMethods(wrapper1); // Miss

--- a/src/services/method-processor.service.ts
+++ b/src/services/method-processor.service.ts
@@ -201,16 +201,6 @@ export class MethodProcessor {
   }
 
   /**
-   * Invalidates cache for a specific class.
-   * This is useful when metadata for a class changes at runtime.
-   *
-   * @param classConstructor - The class constructor to invalidate cache for
-   */
-  invalidateClassCache(classConstructor: Function): void {
-    this.classCache.delete(classConstructor);
-  }
-
-  /**
    * Gets cache statistics for monitoring and debugging.
    *
    * Returns empty stats if monitoring is disabled.


### PR DESCRIPTION
`invalidateClassCache` method is not used, and it could ruin the cache.