### PR TITLE
chore: enable provenance statement in npm release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,6 @@ jobs:
         run: pnpm build
 
       - name: Publish to npm
-        run: npm publish --access public
+        run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
     "README.md",
     "LICENSE"
   ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "author": "miinhho",
   "scripts": {
     "build": "tsc -p tsconfig.build.json",


### PR DESCRIPTION
## Summary
- Enable provenance statement
- Change to managing package release settings in package.json instead of release ci