### PR TITLE
fix: getter-safe method discovery + avoid mutating decorator cache

### DIFF
--- a/src/services/decorator-applier.service.ts
+++ b/src/services/decorator-applier.service.ts
@@ -125,7 +125,9 @@ export class DecoratorApplier {
 
     // To handle decorator order correctly, we sort in ascending order
     // so that lower order decorators are applied first (outermost in the chain).
-    const sortedDecorators = decorators.sort((a, b) => a.order - b.order);
+    // Copy first: `decorators` is shared from MethodProcessor's cache, so sorting
+    // in place would mutate cached state.
+    const sortedDecorators = [...decorators].sort((a, b) => a.order - b.order);
 
     const decoratorsByType: Record<string, AOPDecoratorMetadataWithOrder[]> = {};
     for (const decorator of sortedDecorators) {

--- a/src/services/method-processor.service.spec.ts
+++ b/src/services/method-processor.service.spec.ts
@@ -153,49 +153,6 @@ describe('MethodProcessor', () => {
     });
   });
 
-  describe('getMethodNames', () => {
-    it('should return method names from prototype', () => {
-      class TestClass {
-        method1() {}
-        method2() {}
-        property = 'value';
-      }
-
-      const result = (service as any).getMethodNames(TestClass.prototype);
-
-      expect(result).toEqual(['method1', 'method2']);
-    });
-
-    it('should exclude constructor', () => {
-      class TestClass {
-        constructor() {}
-        method1() {}
-      }
-
-      const result = (service as any).getMethodNames(TestClass.prototype);
-
-      expect(result).toEqual(['method1']);
-    });
-
-    it('should handle invalid prototype', () => {
-      const result = (service as any).getMethodNames(null);
-
-      expect(result).toEqual([]);
-    });
-
-    it('should handle prototype with non-function properties', () => {
-      const prototype = {
-        method1: () => {},
-        property: 'value',
-        method2: 'not a function',
-      };
-
-      const result = (service as any).getMethodNames(prototype);
-
-      expect(result).toEqual(['method1']);
-    });
-  });
-
   describe('getDecorators', () => {
     it('should return decorators with order when decorators exist and have order', () => {
       class TestDecorator {
@@ -268,59 +225,6 @@ describe('MethodProcessor', () => {
       const mockMetatype = { prototype: null };
       const result = (service as any).getPrototype(mockMetatype);
       expect(result).toBeNull();
-    });
-  });
-
-  describe('getMethodNames', () => {
-    it('should return method names from prototype', () => {
-      class TestClass {
-        method1() {}
-        method2() {}
-      }
-      const result = (service as any).getMethodNames(TestClass.prototype);
-      expect(result).toContain('method1');
-      expect(result).toContain('method2');
-      expect(result).not.toContain('constructor');
-    });
-
-    it('should exclude constructor', () => {
-      class TestClass {
-        constructor() {}
-        method1() {}
-      }
-      const result = (service as any).getMethodNames(TestClass.prototype);
-      expect(result).not.toContain('constructor');
-      expect(result).toContain('method1');
-    });
-
-    it('should handle invalid prototype', () => {
-      const result = (service as any).getMethodNames(null);
-      expect(result).toEqual([]);
-    });
-
-    it('should handle prototype with non-function properties', () => {
-      const prototype = {
-        method1() {},
-        property1: 'value',
-        property2: 123,
-      };
-      const result = (service as any).getMethodNames(prototype);
-      expect(result).toContain('method1');
-      expect(result).not.toContain('property1');
-      expect(result).not.toContain('property2');
-    });
-
-    it('should handle error when checking property type', () => {
-      const prototype = {
-        get problematicProperty() {
-          throw new Error('Access error');
-        },
-        normalMethod() {},
-      };
-
-      const result = (service as any).getMethodNames(prototype);
-      expect(result).toContain('normalMethod');
-      expect(result).not.toContain('problematicProperty');
     });
   });
 

--- a/src/services/method-processor.service.ts
+++ b/src/services/method-processor.service.ts
@@ -3,7 +3,7 @@ import { InstanceWrapper } from '@nestjs/core/injector/instance-wrapper';
 import { AOP_ORDER_METADATA_KEY } from '../decorators';
 import { AOPError } from '../error';
 import type { AOPDecoratorMetadata, AOPMethodWithDecorators } from '../interfaces';
-import { AOP_METADATA_KEY, resolveMetatype } from '../utils';
+import { AOP_METADATA_KEY, getAllMethods, resolveMetatype } from '../utils';
 
 interface MethodCache {
   methods: AOPMethodWithDecorators[];
@@ -77,7 +77,7 @@ export class MethodProcessor {
     const prototype = this.getPrototype(metatype);
     if (!prototype) return [];
 
-    const methodNames = this.getMethodNames(prototype);
+    const methodNames = getAllMethods(prototype);
     const methods: AOPMethodWithDecorators[] = [];
 
     for (const methodName of methodNames) {
@@ -104,31 +104,6 @@ export class MethodProcessor {
 
     const prototype = metatype.prototype;
     return typeof prototype === 'object' ? prototype : null;
-  }
-
-  /**
-   * Extracts all method names from a class prototype, filtering out
-   * the constructor and non-function properties.
-   *
-   * @param prototype - The class prototype to analyze
-   *
-   * @returns Array of method names found in the prototype
-   */
-  private getMethodNames(prototype: any): string[] {
-    if (!prototype || typeof prototype !== 'object') {
-      return [];
-    }
-
-    const propertyNames = Object.getOwnPropertyNames(prototype);
-    return propertyNames.filter(name => {
-      if (name === 'constructor') return false;
-
-      try {
-        return typeof prototype[name] === 'function';
-      } catch {
-        return false;
-      }
-    });
   }
 
   /**

--- a/src/utils/get-all-methods.spec.ts
+++ b/src/utils/get-all-methods.spec.ts
@@ -51,6 +51,34 @@ describe('getAllMethods', () => {
     expect(methods).toEqual([]);
   });
 
+  it('should return an empty array for a null or non-object prototype', () => {
+    expect(getAllMethods(null)).toEqual([]);
+    expect(getAllMethods(undefined)).toEqual([]);
+    expect(getAllMethods('not an object')).toEqual([]);
+  });
+
+  it('should not invoke getters while collecting method names', () => {
+    let getterInvoked = false;
+    const prototype = {
+      realMethod() {},
+    };
+    Object.defineProperty(prototype, 'computed', {
+      get() {
+        getterInvoked = true;
+        return () => {};
+      },
+      enumerable: true,
+      configurable: true,
+    });
+
+    const methods = getAllMethods(prototype);
+
+    // The getter must never be executed during discovery...
+    expect(getterInvoked).toBe(false);
+    // ...and a getter (even one returning a function) is not treated as a method.
+    expect(methods).toEqual(['realMethod']);
+  });
+
   it('should handle inherited methods', () => {
     class ParentClass {
       parentMethod() {}

--- a/src/utils/get-all-methods.ts
+++ b/src/utils/get-all-methods.ts
@@ -5,6 +5,10 @@
  * @returns An array of a method name found on the prototype.
  */
 export const getAllMethods = (prototype: any): string[] => {
+  if (!prototype || typeof prototype !== 'object') {
+    return [];
+  }
+
   const propertyKeys = Object.getOwnPropertyNames(prototype);
 
   const methodNames: string[] = [];

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './add-metadata';
 export * from './aop-logger';
+export * from './get-all-methods';
 export * from './resolve-metatype';


### PR DESCRIPTION
## 1. Method discovery invoked getters (bug)

`MethodProcessor.getMethodNames` detected methods with `typeof prototype[name] === 'function'`. Accessing `prototype[name]` **executes getters** at discovery time, and a getter returning a function would be wrongly treated as an AOP target. Meanwhile the class-level `@Aspect` path already used the descriptor-based `getAllMethods`, so the two discovery paths disagreed.

**Fix**
- Drop `getMethodNames` and route `MethodProcessor` through `getAllMethods` (descriptor-based — never invokes getters, correctly excludes getters/setters).
- Export `getAllMethods` from the utils barrel and add a null/non-object guard so it is safe as the single source.
- Remove the now-defunct `getMethodNames` specs; add coverage proving getters are **never** invoked during discovery and that a getter returning a function is not collected.

## 2. Sorting mutated the decorator cache (defensive)

`applyDecorators` ran `decorators.sort(...)` in place, but that array is shared from `MethodProcessor`'s per-class `WeakMap` cache, so the sort mutated cached state. Now sorts a copy (`[...decorators].sort(...)`).

## Test

`140 passed` — lint and `tsc` build both clean. (Net count change vs. main is from removing the duplicated `getMethodNames` specs and adding the getter-safety cases.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)