### PR TITLE
refactor: streamline advice resolution and metatype resolution

### DIFF
--- a/src/services/decorator-applier.service.spec.ts
+++ b/src/services/decorator-applier.service.spec.ts
@@ -601,78 +601,30 @@ describe('DecoratorApplier', () => {
   });
 
   describe('combineChains', () => {
-    it('should execute Spring AOP style execution flow', () => {
+    it('should execute the final execution function with the given args', () => {
       const instance = {};
-      const originalMethod = jest.fn().mockReturnValue('result');
+      const execution = jest.fn().mockReturnValue('result');
 
-      const chains = {
-        [AOP_TYPES.AROUND]: originalMethod, // Final execution in AOP
-        [AOP_TYPES.BEFORE]: undefined,
-        [AOP_TYPES.AFTER]: undefined,
-        [AOP_TYPES.AFTER_RETURNING]: undefined,
-        [AOP_TYPES.AFTER_THROWING]: undefined,
-      };
-
-      const combinedMethod = (service as any).combineChains({
-        chains,
-        originalMethod,
-        instance,
-      });
+      const combinedMethod = (service as any).combineChains({ execution, instance });
 
       const result = combinedMethod('arg1', 'arg2');
 
       expect(result).toBe('result');
-      expect(originalMethod).toHaveBeenCalledWith('arg1', 'arg2');
+      expect(execution).toHaveBeenCalledWith('arg1', 'arg2');
     });
 
-    it('should handle around chain execution', () => {
-      const aroundSpy = jest.fn().mockReturnValue('around-result');
-      const instance = {};
-      const originalMethod = jest.fn();
-
-      const chains = {
-        [AOP_TYPES.AROUND]: aroundSpy,
-        [AOP_TYPES.BEFORE]: undefined,
-        [AOP_TYPES.AFTER]: undefined,
-        [AOP_TYPES.AFTER_RETURNING]: undefined,
-        [AOP_TYPES.AFTER_THROWING]: undefined,
+    it('should bind the instance as `this` when invoking the execution', () => {
+      const instance = { tag: 'inst' };
+      let boundToInstance = false;
+      const execution = function (this: any) {
+        boundToInstance = this === instance;
+        return 'ok';
       };
 
-      const combinedMethod = (service as any).combineChains({
-        chains,
-        originalMethod,
-        instance,
-      });
+      const combinedMethod = (service as any).combineChains({ execution, instance });
 
-      const result = combinedMethod('arg1', 'arg2');
-
-      expect(result).toBe('around-result');
-      expect(aroundSpy).toHaveBeenCalledWith('arg1', 'arg2');
-      expect(originalMethod).not.toHaveBeenCalled(); // Around wraps everything
-    });
-
-    it('should fallback to original method when no Around chain exists', () => {
-      const instance = {};
-      const originalMethod = jest.fn().mockReturnValue('result');
-
-      const chains = {
-        [AOP_TYPES.AROUND]: undefined, // No Around chain
-        [AOP_TYPES.BEFORE]: undefined,
-        [AOP_TYPES.AFTER]: undefined,
-        [AOP_TYPES.AFTER_RETURNING]: undefined,
-        [AOP_TYPES.AFTER_THROWING]: undefined,
-      };
-
-      const combinedMethod = (service as any).combineChains({
-        chains,
-        originalMethod,
-        instance,
-      });
-
-      const result = combinedMethod('arg1', 'arg2');
-
-      expect(result).toBe('result');
-      expect(originalMethod).toHaveBeenCalledWith('arg1', 'arg2');
+      expect(combinedMethod()).toBe('ok');
+      expect(boundToInstance).toBe(true);
     });
   });
 });

--- a/src/services/decorator-applier.service.ts
+++ b/src/services/decorator-applier.service.ts
@@ -60,50 +60,23 @@ type ResolvedAdvice = {
  */
 @Injectable()
 export class DecoratorApplier {
-  private static readonly AOP_PROTOTYPE_APPLIED_SYMBOL = Symbol('aop:prototype:applied');
-
   /**
    * Marker set on the wrapped method so that already-applied methods can be
    * detected without relying on the function name (which minifiers rewrite).
+   *
+   * The marker lives on the method installed on the prototype, so it doubles
+   * as the duplicate-application guard across every instance of the class.
    */
   private static readonly AOP_APPLIED_MARKER = Symbol('aop:applied');
 
   /**
-   * Checks if a method has already been processed to avoid duplicate AOP application.
-   *
-   * Uses both instance-level and prototype-level tracking for comprehensive duplicate prevention.
+   * Checks if a method has already been wrapped with AOP advice, by looking
+   * for the applied-marker on the method currently installed on the prototype.
    */
   private isMethodProcessed(instance: any, methodName: string): boolean {
     const prototype = Object.getPrototypeOf(instance);
-    const prototypeAppliedMethods = prototype[DecoratorApplier.AOP_PROTOTYPE_APPLIED_SYMBOL];
-
-    // Check if we have tracking and this specific method is tracked
-    if (prototypeAppliedMethods?.has(methodName)) {
-      // Double-check by examining the actual method descriptor
-      const descriptor = Object.getOwnPropertyDescriptor(prototype, methodName);
-      if (descriptor?.value?.[DecoratorApplier.AOP_APPLIED_MARKER]) {
-        return true;
-      }
-      // If tracking exists but method isn't actually wrapped, clear the tracking
-      prototypeAppliedMethods.delete(methodName);
-    }
-
-    return false;
-  }
-
-  /**
-   * Marks a method as processed to prevent duplicate AOP application.
-   *
-   * Uses prototype-level tracking for robust duplicate prevention.
-   */
-  private markMethodAsProcessed(instance: any, methodName: string): void {
-    const prototype = Object.getPrototypeOf(instance);
-
-    // Mark at prototype level (primary tracking)
-    if (!prototype[DecoratorApplier.AOP_PROTOTYPE_APPLIED_SYMBOL]) {
-      prototype[DecoratorApplier.AOP_PROTOTYPE_APPLIED_SYMBOL] = new Set<string>();
-    }
-    prototype[DecoratorApplier.AOP_PROTOTYPE_APPLIED_SYMBOL].add(methodName);
+    const descriptor = Object.getOwnPropertyDescriptor(prototype, methodName);
+    return Boolean(descriptor?.value?.[DecoratorApplier.AOP_APPLIED_MARKER]);
   }
 
   /**
@@ -161,11 +134,10 @@ export class DecoratorApplier {
     // Wrap so the instance is bound as `this` and the applied-marker is attached.
     const combinedMethod = this.combineChains({ execution, instance });
 
+    // Installing the marker-tagged method also records that it has been
+    // processed, so isMethodProcessed will short-circuit any future calls.
     descriptor.value = combinedMethod;
     Object.defineProperty(prototype, methodName, descriptor);
-
-    // Mark method as processed to prevent future duplicate processing
-    this.markMethodAsProcessed(instance, methodName);
   }
 
   /**

--- a/src/services/decorator-applier.service.ts
+++ b/src/services/decorator-applier.service.ts
@@ -2,16 +2,10 @@ import { Injectable } from '@nestjs/common';
 import {
   AOP_TYPES,
   AOPDecoratorMetadataWithOrder,
-  AOPType,
+  AOPOptions,
   type IAOPDecorator,
 } from '../interfaces';
 import { logger } from '../utils';
-
-/**
- * Type definition for chains of AOP advice functions.
- * @internal
- */
-type ChainFunctions = Record<AOPType, Function | undefined>;
 
 /**
  * Parameters for applying AOP decorators to a method.
@@ -43,6 +37,18 @@ type DecoratorSearchParams = {
 };
 
 /**
+ * An AOP decorator instance resolved from its metadata, paired with the
+ * options the advice was registered with. Resolved once at apply-time so the
+ * runtime hot path never has to look the instance up again.
+ *
+ * @internal
+ */
+type ResolvedAdvice = {
+  instance: IAOPDecorator;
+  options: AOPOptions;
+};
+
+/**
  * Service for applying AOP decorators to methods
  *
  * This service is for taking AOP decorator metadata and applying
@@ -57,6 +63,12 @@ export class DecoratorApplier {
   private static readonly AOP_PROTOTYPE_APPLIED_SYMBOL = Symbol('aop:prototype:applied');
 
   /**
+   * Marker set on the wrapped method so that already-applied methods can be
+   * detected without relying on the function name (which minifiers rewrite).
+   */
+  private static readonly AOP_APPLIED_MARKER = Symbol('aop:applied');
+
+  /**
    * Checks if a method has already been processed to avoid duplicate AOP application.
    *
    * Uses both instance-level and prototype-level tracking for comprehensive duplicate prevention.
@@ -69,7 +81,7 @@ export class DecoratorApplier {
     if (prototypeAppliedMethods?.has(methodName)) {
       // Double-check by examining the actual method descriptor
       const descriptor = Object.getOwnPropertyDescriptor(prototype, methodName);
-      if (descriptor?.value?.name === 'combinedAOPMethod') {
+      if (descriptor?.value?.[DecoratorApplier.AOP_APPLIED_MARKER]) {
         return true;
       }
       // If tracking exists but method isn't actually wrapped, clear the tracking
@@ -138,7 +150,7 @@ export class DecoratorApplier {
       decoratorsByType[type].push(decorator);
     }
 
-    const chains = this.createAllChains({
+    const execution = this.createExecution({
       decoratorsByType,
       aopDecorators,
       originalMethod,
@@ -146,8 +158,8 @@ export class DecoratorApplier {
       instance,
     });
 
-    // Create a named function for better debugging and duplicate detection
-    const combinedMethod = this.combineChains({ chains, originalMethod, instance });
+    // Wrap so the instance is bound as `this` and the applied-marker is attached.
+    const combinedMethod = this.combineChains({ execution, instance });
 
     descriptor.value = combinedMethod;
     Object.defineProperty(prototype, methodName, descriptor);
@@ -187,19 +199,40 @@ export class DecoratorApplier {
   }
 
   /**
-   * Creates chains for all decorator types using Spring AOP execution order.
+   * Resolves a list of decorator metadata into advice instances paired with
+   * their options, keeping only those whose instance implements `adviceKey`.
    *
-   * AOP order: Around wraps the entire execution flow including Before/After advice.
+   * This runs once at apply-time, so the runtime advice loops never call
+   * {@link findTargetDecorator} (a linear search) on every invocation.
    *
-   * @param params.decoratorsByType - Record of decorator types to their corresponding metadata arrays
-   * @param params.aopDecorators - The list of available AOP decorator instances
-   * @param params.originalMethod - The original method function
-   * @param params.methodName - The name of the method being processed
-   * @param params.instance - The target instance
-   *
-   * @returns An object mapping each AOP type to its corresponding chain function
+   * @returns Resolved advices in metadata (already order-sorted) order
    */
-  private createAllChains({
+  private resolveAdvices(
+    decorators: AOPDecoratorMetadataWithOrder[],
+    aopDecorators: IAOPDecorator[],
+    methodName: string,
+    adviceKey: keyof IAOPDecorator,
+  ): ResolvedAdvice[] {
+    const resolved: ResolvedAdvice[] = [];
+    for (const decorator of decorators) {
+      const instance = this.findTargetDecorator({ decorator, aopDecorators, methodName });
+      if (instance && typeof instance[adviceKey] === 'function') {
+        resolved.push({ instance, options: decorator.options });
+      }
+    }
+    return resolved;
+  }
+
+  /**
+   * Builds the final execution function for a method using Spring AOP execution order.
+   *
+   * Around advice wraps the core execution (Before -> Method ->
+   * AfterReturning/AfterThrowing -> After). When no Around advice exists, the
+   * core execution itself is the final execution.
+   *
+   * @returns The function that runs the original method wrapped with all advice
+   */
+  private createExecution({
     decoratorsByType,
     aopDecorators,
     originalMethod,
@@ -208,8 +241,8 @@ export class DecoratorApplier {
   }: {
     decoratorsByType: Record<string, AOPDecoratorMetadataWithOrder[]>;
     instance: any;
-  } & Omit<ChainCreationParams, 'decorators'>): ChainFunctions {
-    // Create core execution method that includes Before/After advice around the original method
+  } & Omit<ChainCreationParams, 'decorators'>): Function {
+    // Core execution wraps the original method with Before/After advice.
     const coreExecution = this.createCoreExecution({
       decoratorsByType,
       aopDecorators,
@@ -218,40 +251,31 @@ export class DecoratorApplier {
       instance,
     });
 
-    // If Around decorators exist, wrap the core execution
-    const aroundDecorators = decoratorsByType[AOP_TYPES.AROUND];
-    const finalExecution =
-      (aroundDecorators?.length ?? 0) > 0
-        ? aroundDecorators!.reduceRight((nextMethod, decorator) => {
-            const targetDecorator = this.findTargetDecorator({
-              decorator,
-              aopDecorators,
-              methodName,
-            });
-            if (targetDecorator?.around) {
-              return function (this: any, ...args: any[]) {
-                const context = {
-                  method: originalMethod,
-                  instance: this,
-                  options: decorator.options,
-                  proceed: (...proceedArgs: any[]) => nextMethod.call(this, ...proceedArgs),
-                };
+    // Around advice (resolved once) wraps the core execution from the inside out.
+    const aroundAdvices = this.resolveAdvices(
+      decoratorsByType[AOP_TYPES.AROUND] ?? [],
+      aopDecorators,
+      methodName,
+      'around',
+    );
 
-                const aroundWrapper = targetDecorator.around!(context);
-                return aroundWrapper.call(this, ...args);
-              };
-            }
-            return nextMethod;
-          }, coreExecution)
-        : coreExecution;
+    if (aroundAdvices.length === 0) {
+      return coreExecution;
+    }
 
-    return {
-      [AOP_TYPES.AROUND]: finalExecution,
-      [AOP_TYPES.BEFORE]: undefined,
-      [AOP_TYPES.AFTER]: undefined,
-      [AOP_TYPES.AFTER_RETURNING]: undefined,
-      [AOP_TYPES.AFTER_THROWING]: undefined,
-    };
+    return aroundAdvices.reduceRight((nextMethod, { instance: advice, options }) => {
+      return function (this: any, ...args: any[]) {
+        const context = {
+          method: originalMethod,
+          instance: this,
+          options,
+          proceed: (...proceedArgs: any[]) => nextMethod.call(this, ...proceedArgs),
+        };
+
+        const aroundWrapper = advice.around!(context);
+        return aroundWrapper.call(this, ...args);
+      };
+    }, coreExecution);
   }
 
   /**
@@ -267,54 +291,43 @@ export class DecoratorApplier {
     decoratorsByType: Record<string, AOPDecoratorMetadataWithOrder[]>;
     instance: any;
   } & Omit<ChainCreationParams, 'decorators'>): Function {
-    const beforeDecorators = decoratorsByType[AOP_TYPES.BEFORE] ?? [];
-    const afterDecorators = decoratorsByType[AOP_TYPES.AFTER] ?? [];
-    const afterReturningDecorators = decoratorsByType[AOP_TYPES.AFTER_RETURNING] ?? [];
-    const afterThrowingDecorators = decoratorsByType[AOP_TYPES.AFTER_THROWING] ?? [];
+    // Resolve every advice instance once, up front, so the returned closure
+    // never performs a lookup while the method is being called.
+    const resolve = (type: string, adviceKey: keyof IAOPDecorator) =>
+      this.resolveAdvices(decoratorsByType[type] ?? [], aopDecorators, methodName, adviceKey);
+
+    const beforeAdvices = resolve(AOP_TYPES.BEFORE, 'before');
+    const afterAdvices = resolve(AOP_TYPES.AFTER, 'after');
+    const afterReturningAdvices = resolve(AOP_TYPES.AFTER_RETURNING, 'afterReturning');
+    const afterThrowingAdvices = resolve(AOP_TYPES.AFTER_THROWING, 'afterThrowing');
+
+    const runBefore = (args: any[]) => {
+      for (const { instance: advice, options } of beforeAdvices) {
+        advice.before!({ method: originalMethod, options })(...args);
+      }
+    };
 
     const runAfterReturning = (result: any, args: any[]) => {
-      for (const decorator of afterReturningDecorators) {
-        const targetDecorator = this.findTargetDecorator({ decorator, aopDecorators, methodName });
-        targetDecorator?.afterReturning?.({
-          method: originalMethod,
-          options: decorator.options,
-          result,
-        })(...args);
+      for (const { instance: advice, options } of afterReturningAdvices) {
+        advice.afterReturning!({ method: originalMethod, options, result })(...args);
       }
     };
 
     const runAfterThrowing = (error: unknown, args: any[]) => {
-      for (const decorator of afterThrowingDecorators) {
-        const targetDecorator = this.findTargetDecorator({ decorator, aopDecorators, methodName });
-        targetDecorator?.afterThrowing?.({
-          method: originalMethod,
-          options: decorator.options,
-          error,
-        })(...args);
+      for (const { instance: advice, options } of afterThrowingAdvices) {
+        advice.afterThrowing!({ method: originalMethod, options, error })(...args);
       }
     };
 
     const runAfter = (args: any[]) => {
-      for (const decorator of afterDecorators) {
-        const targetDecorator = this.findTargetDecorator({ decorator, aopDecorators, methodName });
-        targetDecorator?.after?.({
-          method: originalMethod,
-          options: decorator.options,
-        })(...args);
+      for (const { instance: advice, options } of afterAdvices) {
+        advice.after!({ method: originalMethod, options })(...args);
       }
     };
 
     return (...args: any[]) => {
       // Execute Before advice
-      for (const decorator of beforeDecorators) {
-        const targetDecorator = this.findTargetDecorator({ decorator, aopDecorators, methodName });
-        if (targetDecorator?.before) {
-          targetDecorator.before({
-            method: originalMethod,
-            options: decorator.options,
-          })(...args);
-        }
-      }
+      runBefore(args);
 
       let result: any;
       try {
@@ -352,36 +365,26 @@ export class DecoratorApplier {
   }
 
   /**
-   * Combines all chains into a single method using Spring AOP execution order.
+   * Wraps the final execution function into the method placed on the prototype.
    *
-   * The chains object now contains only the final execution function that includes
-   * all advice properly ordered: Around wraps (Before -> Method -> AfterReturning/AfterThrowing -> After).
+   * Binds the instance as `this` (so Around advice sees the right receiver) and
+   * tags the wrapper with the applied-marker for duplicate detection.
    *
-   * @param params.chains - The chains to combine (now simplified)
-   * @param params.originalMethod - The original method function
+   * @param params.execution - The final execution function (with all advice applied)
    * @param params.instance - The instance of the class containing the method
    *
-   * @returns A new function that combines all AOP advice and the original method
+   * @returns The method to install on the prototype
    */
-  private combineChains({
-    chains,
-    originalMethod,
-    instance,
-  }: {
-    chains: ChainFunctions;
-    originalMethod: Function;
-    instance: any;
-  }): Function {
-    return function combinedAOPMethod(...args: any[]) {
-      // Around wraps everything, or execute core if no Around
-      const finalExecution = chains[AOP_TYPES.AROUND];
-      if (finalExecution) {
-        // finalExecution is already a wrapped function that handles the around advice
-        return finalExecution.call(instance, ...args);
-      } else {
-        // No around advice, execute the original method directly
-        return originalMethod.apply(instance, args);
-      }
+  private combineChains({ execution, instance }: { execution: Function; instance: any }): Function {
+    const combinedAOPMethod = function (this: any, ...args: any[]) {
+      return execution.call(instance, ...args);
     };
+
+    Object.defineProperty(combinedAOPMethod, DecoratorApplier.AOP_APPLIED_MARKER, {
+      value: true,
+      enumerable: false,
+    });
+
+    return combinedAOPMethod;
   }
 }

--- a/src/services/method-processor.service.spec.ts
+++ b/src/services/method-processor.service.spec.ts
@@ -207,69 +207,6 @@ describe('MethodProcessor', () => {
         (service as any).getDecorators(TestDecorator, 'testMethod');
       }).toThrow(AOPError);
     });
-  });
-
-  describe('getPrototype', () => {
-    it('should return prototype for valid metatype', () => {
-      class TestClass {}
-      const result = (service as any).getPrototype(TestClass);
-      expect(result).toBe(TestClass.prototype);
-    });
-
-    it('should return null for invalid metatype', () => {
-      const result = (service as any).getPrototype(null);
-      expect(result).toBeNull();
-    });
-
-    it('should return null if prototype is invalid', () => {
-      const mockMetatype = { prototype: null };
-      const result = (service as any).getPrototype(mockMetatype);
-      expect(result).toBeNull();
-    });
-  });
-
-  describe('getDecorators', () => {
-    it('should return decorators with order when decorators exist and have order', () => {
-      class TestDecorator {}
-      const mockDecorators = [
-        { type: AOP_TYPES.BEFORE, options: {}, decoratorClass: TestDecorator },
-      ];
-
-      jest.spyOn(service as any, 'getAspectDecorator').mockReturnValue(mockDecorators);
-      jest.spyOn(Reflect, 'getMetadata').mockReturnValue(5);
-
-      const result = (service as any).getDecorators(TestDecorator, 'testMethod');
-
-      expect(result).toEqual([{ ...mockDecorators[0], order: 5 }]);
-    });
-
-    it('should throw AOPError decorators with order when decorators exist and have non-number order', () => {
-      class TestDecorator {}
-      const mockDecorators = [
-        { type: AOP_TYPES.BEFORE, options: {}, decoratorClass: TestDecorator },
-      ];
-
-      jest.spyOn(service as any, 'getAspectDecorator').mockReturnValue(mockDecorators);
-      jest.spyOn(Reflect, 'getMetadata').mockReturnValue('invalid-order');
-
-      expect(() => {
-        (service as any).getDecorators(TestDecorator, 'testMethod');
-      }).toThrow(AOPError);
-    });
-
-    it('should throw AOPError when decorator has no order metadata', () => {
-      class TestDecorator {}
-      const mockDecorators = [
-        { type: AOP_TYPES.BEFORE, options: {}, decoratorClass: TestDecorator },
-      ];
-
-      jest.spyOn(service as any, 'getAspectDecorator').mockReturnValue(mockDecorators);
-      jest.spyOn(Reflect, 'getMetadata').mockReturnValue(undefined);
-
-      expect(() => {
-        (service as any).getDecorators(TestDecorator, 'testMethod');
-      }).toThrow(AOPError);
-    });
 
     it('should return undefined when no decorators exist', () => {
       const methodName = 'testMethod';

--- a/src/utils/resolve-metatype.ts
+++ b/src/utils/resolve-metatype.ts
@@ -1,6 +1,57 @@
 import { InstanceWrapper } from '@nestjs/core/injector/instance-wrapper';
 
 /**
+ * Whether `metatype` is a real class constructor rather than a factory
+ * function. Arrow/async factory functions have no class-style prototype, and
+ * the native `Function` constructor is explicitly excluded.
+ */
+function isClassConstructor(metatype: Function): boolean {
+  const prototype = metatype.prototype;
+  return (
+    !!prototype &&
+    typeof prototype === 'object' &&
+    metatype !== Function &&
+    prototype.constructor === metatype
+  );
+}
+
+/**
+ * Whether a class `metatype` can be used as the resolved type for `instance`.
+ *
+ * It qualifies when it actually declares methods, when it is the constructor
+ * of the given instance, or when there is no instance to cross-check against.
+ */
+function metatypeMatchesInstance(metatype: Function, instance: unknown): boolean {
+  const prototypeKeys = Object.getOwnPropertyNames(metatype.prototype);
+  const hasClassMethods =
+    prototypeKeys.length > 1 || (prototypeKeys.length === 1 && prototypeKeys[0] !== 'constructor');
+  const instanceMatchesMetatype = !!instance && (instance as any).constructor === metatype;
+  const hasNoInstance = !instance;
+
+  return hasClassMethods || instanceMatchesMetatype || hasNoInstance;
+}
+
+/**
+ * Recovers the constructor from a (factory-created) instance via its
+ * prototype, ignoring plain `Object`/`Function` constructors.
+ */
+function resolveConstructorFromInstance(instance: object): Function | null {
+  const instancePrototype = Object.getPrototypeOf(instance);
+  const constructor = instancePrototype?.constructor;
+
+  if (
+    typeof constructor === 'function' &&
+    constructor !== Object &&
+    constructor !== Function &&
+    constructor.name !== 'Object'
+  ) {
+    return constructor;
+  }
+
+  return null;
+}
+
+/**
  * Resolves the class constructor from a wrapper, supporting both
  * regular class-based providers and factory-created instances.
  *
@@ -10,59 +61,24 @@ import { InstanceWrapper } from '@nestjs/core/injector/instance-wrapper';
  * @internal
  */
 export function resolveMetatype(wrapper: InstanceWrapper): Function | null {
-  // Handle null or undefined wrapper
   if (!wrapper) {
     return null;
   }
 
-  // First, try the standard metatype (for regular class-based providers)
-  if (wrapper.metatype && typeof wrapper.metatype === 'function') {
-    // Check if metatype is a real class constructor (not a factory function)
-    if (
-      wrapper.metatype.prototype &&
-      typeof wrapper.metatype.prototype === 'object' &&
-      wrapper.metatype !== Function &&
-      wrapper.metatype.prototype.constructor === wrapper.metatype
-    ) {
-      // Additional check: typically have more than just constructor on prototype
-      const prototypeKeys = Object.getOwnPropertyNames(wrapper.metatype.prototype);
-      const hasClassMethods =
-        prototypeKeys.length > 1 || // More than just 'constructor'
-        (prototypeKeys.length === 1 && prototypeKeys[0] !== 'constructor'); // Or has methods but not constructor
+  const { metatype, instance } = wrapper;
 
-      // Or check if it looks like a class by checking if instance matches the metatype
-      const instanceMatchesMetatype =
-        wrapper.instance && wrapper.instance.constructor === wrapper.metatype;
-
-      const hasNoInstance = !wrapper.instance;
-
-      if (hasClassMethods || instanceMatchesMetatype || hasNoInstance) {
-        return wrapper.metatype;
-      }
+  // Regular class-based providers: prefer the metatype when it is a real class.
+  if (typeof metatype === 'function' && isClassConstructor(metatype)) {
+    if (metatypeMatchesInstance(metatype, instance)) {
+      return metatype;
     }
   }
 
-  if (!wrapper.instance) {
+  // Factory providers: the metatype is the factory, so recover the class from
+  // the instance it produced.
+  if (!instance) {
     return null;
   }
 
-  // For factory providers, use Object.getPrototypeOf to get the actual prototype
-  // then get the constructor from that prototype
-  const instancePrototype = Object.getPrototypeOf(wrapper.instance);
-  if (instancePrototype && instancePrototype.constructor) {
-    const constructor = instancePrototype.constructor;
-
-    // Make sure it's a valid constructor and not Object or Function
-    if (
-      constructor &&
-      typeof constructor === 'function' &&
-      constructor !== Object &&
-      constructor !== Function &&
-      constructor.name !== 'Object'
-    ) {
-      return constructor;
-    }
-  }
-
-  return null;
+  return resolveConstructorFromInstance(instance);
 }


### PR DESCRIPTION
Internal refactors with no change in observable behavior. The full unit and e2e suites (async, ordered, class-level, and factory-provider cases included) pass, lint and `tsc` build are clean.

## Resolve advice instances once and simplify chain construction

`decorator-applier.service.ts`:
- The runtime advice loops resolved the decorator instance for each advice on **every method invocation** via a linear `aopDecorators.find`. They now iterate over pre-resolved `{instance, options}` pairs computed once at apply-time (`resolveAdvices`). The "no matching instance" warning also fires once at startup instead of on every call.
- Removed the vestigial five-key chain map: `createAllChains` returned a record where only the `AROUND` entry was ever populated, and `combineChains`' no-Around fallback branch was unreachable. Replaced with a single `createExecution` returning one execution function.
- Already-applied methods are now detected with a non-enumerable `Symbol` marker on the wrapper instead of comparing `function.name` to `'combinedAOPMethod'`, which minifiers rewrite.

`combineChains` specs updated to the new single-execution signature (incl. a case asserting the instance is bound as `this`).

## Drop the applied-methods Set, rely on the marker alone

Duplicate-application was guarded by two mechanisms: a `Set` of processed method names stored on the prototype **and** the `Symbol` marker on the wrapped method. The Set only mirrored what the marker already proves, and the marker is checked on every call anyway, so it added bookkeeping without affecting correctness.

Removed the Set and `markMethodAsProcessed`: installing the marker-tagged method on the prototype is itself the record that it was processed, so `isMethodProcessed` just checks for the marker on the installed method. Because the marker lives on the prototype method, cross-instance de-duplication is preserved.

## Decompose resolveMetatype into named predicates

`resolve-metatype.ts` was one function with deeply nested conditionals mixing two strategies. Extracted `isClassConstructor`, `metatypeMatchesInstance`, and `resolveConstructorFromInstance` so the top-level flow reads as: prefer a real class metatype, otherwise recover the class from the instance a factory produced.

## Remove duplicated spec blocks

`method-processor.service.spec.ts` had two near-identical `describe` blocks each for `getPrototype` and `getDecorators`. Collapsed to one each, preserving the unique `getDecorators` cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)