### PR TITLE
refactor: drop unused cache-statistics tracking and tighten getDecorators type

### DIFF
--- a/src/services/method-processor.cache.spec.ts
+++ b/src/services/method-processor.cache.spec.ts
@@ -10,383 +10,172 @@ describe('MethodProcessor - Cache Functionality', () => {
     service = new MethodProcessor();
   });
 
+  /**
+   * Spies on Reflect.getMetadata and counts how many times method-level AOP
+   * metadata is read, which only happens while a class is (re)processed. A
+   * cache hit performs no such reads, so the counter reveals reprocessing.
+   */
+  const trackProcessing = (decoratorClass: Function = class {}) => {
+    const counter = { reads: 0 };
+    jest.spyOn(Reflect, 'getMetadata').mockImplementation((key, _target, propertyKey) => {
+      if (key === AOP_METADATA_KEY) {
+        if (propertyKey !== undefined) counter.reads++;
+        return propertyKey === 'method1'
+          ? [{ type: AOP_TYPES.BEFORE, options: {}, decoratorClass }]
+          : undefined;
+      }
+      if (key === AOP_ORDER_METADATA_KEY) return 0;
+      return undefined;
+    });
+    return counter;
+  };
+
   describe('WeakMap primary cache', () => {
-    it('should cache results using WeakMap with class constructor as key', () => {
+    it('should return the cached result by reference on repeated calls', () => {
       class TestClass {
         method1() {}
       }
-      class TestDecorator {}
+      const counter = trackProcessing();
+      const wrapper = { instance: new TestClass(), metatype: TestClass } as any;
 
-      const wrapper = {
-        instance: new TestClass(),
-        metatype: TestClass,
-      } as any;
+      const first = service.processInstanceMethods(wrapper);
+      const readsAfterFirst = counter.reads;
 
-      jest.spyOn(Reflect, 'getMetadata').mockImplementation((key, target, propertyKey) => {
-        if (key === AOP_METADATA_KEY && propertyKey === 'method1') {
-          return [{ type: AOP_TYPES.BEFORE, options: {}, decoratorClass: TestDecorator }];
-        }
-        if (key === AOP_ORDER_METADATA_KEY && target === TestDecorator) {
-          return 0;
-        }
-        return undefined;
-      });
+      const second = service.processInstanceMethods(wrapper);
 
-      // First call - should process and cache
-      const result1 = service.processInstanceMethods(wrapper);
-      const stats1 = service.getCacheStats();
+      expect(first.methods).toHaveLength(1);
+      expect(first.metatype).toBe(TestClass);
+      // Same object reference from the cache, and no reprocessing happened.
+      expect(second).toBe(first);
+      expect(counter.reads).toBe(readsAfterFirst);
+    });
 
-      expect(stats1.misses).toBe(1);
-      expect(stats1.hits).toBe(0);
-      expect(result1.methods).toHaveLength(1);
-      expect(result1.metatype).toBe(TestClass);
+    it('should not reprocess across many repeated calls', () => {
+      class TestClass {
+        method1() {}
+        method2() {}
+        method3() {}
+      }
+      const counter = trackProcessing();
+      const wrapper = { instance: new TestClass(), metatype: TestClass } as any;
 
-      // Second call - should use cache
-      const result2 = service.processInstanceMethods(wrapper);
-      const stats2 = service.getCacheStats();
+      service.processInstanceMethods(wrapper);
+      const readsAfterFirst = counter.reads;
+      expect(readsAfterFirst).toBeGreaterThan(0);
 
-      expect(stats2.misses).toBe(1);
-      expect(stats2.hits).toBe(1);
-      expect(result2).toEqual(result1);
-      expect(result2).toBe(result1);
+      for (let i = 0; i < 100; i++) {
+        service.processInstanceMethods(wrapper);
+      }
+
+      expect(counter.reads).toBe(readsAfterFirst);
     });
   });
 
-  describe('Cache invalidation', () => {
-    it('should clear all caches and reset statistics', () => {
-      class TestClass {
-        method1() {}
-      }
-
-      const wrapper = { instance: new TestClass(), metatype: TestClass } as any;
-      jest.spyOn(Reflect, 'getMetadata').mockReturnValue(undefined);
-
-      // Populate caches
-      service.processInstanceMethods(wrapper);
-      service.processInstanceMethods(wrapper);
-
-      let stats = service.getCacheStats();
-      expect(stats.misses).toBe(1);
-      expect(stats.hits).toBe(1);
-
-      service.clearCaches();
-
-      stats = service.getCacheStats();
-      expect(stats.misses).toBe(0);
-      expect(stats.hits).toBe(0);
-
-      // Next call should be a miss again
-      service.processInstanceMethods(wrapper);
-      stats = service.getCacheStats();
-      expect(stats.misses).toBe(1);
-    });
-
-    it('should invalidate cache for specific class', () => {
+  describe('Per-class caching', () => {
+    it('should cache each class independently', () => {
       class TestClass1 {
         method1() {}
       }
       class TestClass2 {
         method1() {}
       }
+      trackProcessing();
 
       const wrapper1 = { instance: new TestClass1(), metatype: TestClass1 } as any;
       const wrapper2 = { instance: new TestClass2(), metatype: TestClass2 } as any;
 
-      jest.spyOn(Reflect, 'getMetadata').mockReturnValue(undefined);
+      const a1 = service.processInstanceMethods(wrapper1);
+      const b1 = service.processInstanceMethods(wrapper2);
 
-      // Populate both caches
-      service.processInstanceMethods(wrapper1);
-      service.processInstanceMethods(wrapper2);
-      service.processInstanceMethods(wrapper1); // Hit cache
-      service.processInstanceMethods(wrapper2); // Hit cache
+      expect(service.processInstanceMethods(wrapper1)).toBe(a1);
+      expect(service.processInstanceMethods(wrapper2)).toBe(b1);
+      expect(a1).not.toBe(b1);
+    });
 
-      let stats = service.getCacheStats();
-      expect(stats.hits).toBe(2);
+    it('should reprocess a class after its cache entry is removed', () => {
+      class TestClass {
+        method1() {}
+      }
+      const counter = trackProcessing();
+      const wrapper = { instance: new TestClass(), metatype: TestClass } as any;
 
-      // Invalidate only TestClass1
-      (service as any).classCache.delete(TestClass1);
+      service.processInstanceMethods(wrapper);
+      const readsAfterFirst = counter.reads;
 
-      // TestClass1 should miss, TestClass2 should hit
-      service.processInstanceMethods(wrapper1); // Miss
-      service.processInstanceMethods(wrapper2); // Hit
+      (service as any).classCache.delete(TestClass);
 
-      stats = service.getCacheStats();
-      expect(stats.misses).toBe(3); // 2 initial + 1 after invalidation
-      expect(stats.hits).toBe(3); // 2 before + 1 TestClass2 hit
+      service.processInstanceMethods(wrapper);
+      expect(counter.reads).toBeGreaterThan(readsAfterFirst);
     });
   });
 
-  describe('Cache performance validation', () => {
-    it('should demonstrate significant performance improvement with cache', () => {
+  describe('Cache isolation', () => {
+    it('should not share cache between different service instances', () => {
       class TestClass {
         method1() {}
-        method2() {}
-        method3() {}
       }
-      class TestDecorator {}
-
+      trackProcessing();
       const wrapper = { instance: new TestClass(), metatype: TestClass } as any;
 
-      // Mock complex metadata processing
-      let processCallCount = 0;
-      jest.spyOn(Reflect, 'getMetadata').mockImplementation(key => {
-        if (key === AOP_METADATA_KEY) {
-          processCallCount++;
-          return [{ type: AOP_TYPES.BEFORE, options: {}, decoratorClass: TestDecorator }];
-        }
-        if (key === AOP_ORDER_METADATA_KEY) {
-          return 1;
-        }
-        return undefined;
-      });
+      const fromService1 = new MethodProcessor().processInstanceMethods(wrapper);
+      const fromService2 = new MethodProcessor().processInstanceMethods(wrapper);
 
-      // First call - should process all methods
-      service.processInstanceMethods(wrapper);
-
-      const initialProcessCalls = processCallCount;
-      expect(initialProcessCalls).toBeGreaterThan(0);
-
-      // Reset call count to measure cache performance
-      processCallCount = 0;
-
-      // Subsequent calls - should use cache
-      for (let i = 0; i < 100; i++) {
-        service.processInstanceMethods(wrapper);
-      }
-
-      // Cache should prevent reprocessing
-      expect(processCallCount).toBe(0);
-
-      // Verify cache statistics
-      const stats = service.getCacheStats();
-      expect(stats.hits).toBe(100);
-      expect(stats.misses).toBe(1);
-
-      // Performance should be significantly better (though timing is environment-dependent)
-      // We mainly check that no reprocessing occurred
-      expect(processCallCount).toBe(0);
-    });
-
-    it('should handle high-frequency cache operations efficiently', () => {
-      const classes = [];
-      const wrappers = [] as any[];
-
-      for (let i = 0; i < 50; i++) {
-        const TestClass = class {
-          method1() {}
-        };
-        Object.defineProperty(TestClass, 'name', { value: `TestClass${i}` });
-        classes.push(TestClass);
-        wrappers.push({ instance: new TestClass(), metatype: TestClass });
-      }
-
-      jest.spyOn(Reflect, 'getMetadata').mockReturnValue(undefined);
-
-      wrappers.forEach(wrapper => service.processInstanceMethods(wrapper));
-
-      const iterations = 1000;
-      const start = Date.now();
-
-      for (let i = 0; i < iterations; i++) {
-        const randomWrapper = wrappers[i % wrappers.length];
-        service.processInstanceMethods(randomWrapper);
-      }
-
-      const elapsed = Date.now() - start;
-      const stats = service.getCacheStats();
-
-      // Should be mostly cache hits
-      expect(stats.hits).toBe(iterations);
-      expect(stats.misses).toBe(50); // One per class
-
-      // Performance should be reasonable (< 1ms per operation on average)
-      const avgTime = elapsed / iterations;
-      expect(avgTime).toBeLessThan(1);
-
-      console.log(`Cache performance: ${avgTime.toFixed(3)}ms per operation`);
-      console.log(`Cache stats:`, stats);
-      console.log(`Cache hit rate: ${service.getCacheHitRate().toFixed(1)}%`);
+      // Structurally equal, but each service produced its own cached object.
+      expect(fromService2).toEqual(fromService1);
+      expect(fromService2).not.toBe(fromService1);
     });
   });
 
   describe('Edge cases', () => {
-    it('should handle invalid wrapper gracefully', () => {
-      const result1 = service.processInstanceMethods(null as any);
-      const result2 = service.processInstanceMethods(undefined as any);
-      const result3 = service.processInstanceMethods({} as any);
-      const result4 = service.processInstanceMethods({ instance: null } as any);
-      const result5 = service.processInstanceMethods({ metatype: null } as any);
+    it('should handle invalid wrappers gracefully without caching', () => {
+      jest.spyOn(Reflect, 'getMetadata').mockReturnValue(undefined);
 
-      expect(result1).toEqual({ methods: [], metatype: null });
-      expect(result2).toEqual({ methods: [], metatype: null });
-      expect(result3).toEqual({ methods: [], metatype: null });
-      expect(result4).toEqual({ methods: [], metatype: null });
-      expect(result5).toEqual({ methods: [], metatype: null });
-
-      // Should not affect cache statistics for invalid inputs
-      const stats = service.getCacheStats();
-      expect(stats.misses).toBe(0);
-      expect(stats.hits).toBe(0);
+      expect(service.processInstanceMethods(null as any)).toEqual({ methods: [], metatype: null });
+      expect(service.processInstanceMethods(undefined as any)).toEqual({
+        methods: [],
+        metatype: null,
+      });
+      expect(service.processInstanceMethods({} as any)).toEqual({ methods: [], metatype: null });
+      expect(service.processInstanceMethods({ instance: null } as any)).toEqual({
+        methods: [],
+        metatype: null,
+      });
+      expect(service.processInstanceMethods({ metatype: null } as any)).toEqual({
+        methods: [],
+        metatype: null,
+      });
     });
 
     it('should handle classes with prototype pollution attempts', () => {
       class TestClass {
         method1() {}
       }
-
       (TestClass.prototype as any).__proto__ = { maliciousMethod: () => {} };
 
       const wrapper = { instance: new TestClass(), metatype: TestClass } as any;
       jest.spyOn(Reflect, 'getMetadata').mockReturnValue(undefined);
 
-      // Should not include polluted methods and not crash
       const result = service.processInstanceMethods(wrapper);
       expect(result.methods).toEqual([]);
       expect(result.metatype).toBe(TestClass);
 
-      // Should still cache safely
-      const result2 = service.processInstanceMethods(wrapper);
-      expect(result2).toEqual(result);
-
-      const stats = service.getCacheStats();
-      expect(stats.hits).toBe(1);
+      // Still cached safely.
+      expect(service.processInstanceMethods(wrapper)).toBe(result);
     });
 
-    it('should handle concurrent access safely', async () => {
+    it('should return the same cached reference under concurrent access', async () => {
       class TestClass {
         method1() {}
       }
-
       const wrapper = { instance: new TestClass(), metatype: TestClass } as any;
       jest.spyOn(Reflect, 'getMetadata').mockReturnValue(undefined);
 
-      // Simulate concurrent access
-      const promises = Array.from({ length: 100 }, () =>
-        Promise.resolve(service.processInstanceMethods(wrapper)),
+      const results = await Promise.all(
+        Array.from({ length: 100 }, () => Promise.resolve(service.processInstanceMethods(wrapper))),
       );
 
-      const results = await Promise.all(promises);
-
-      // All results should be identical
-      const firstResult = results[0];
-      results.forEach(result => {
-        expect(result).toBe(firstResult); // Same reference from cache
-      });
-
-      const stats = service.getCacheStats();
-      expect(stats.misses).toBe(1);
-      expect(stats.hits).toBe(99);
-    });
-  });
-
-  describe('Test isolation', () => {
-    it('should not share cache between different service instances', () => {
-      class TestClass {
-        method1() {}
-      }
-
-      const service1 = new MethodProcessor();
-      const service2 = new MethodProcessor();
-      const wrapper = { instance: new TestClass(), metatype: TestClass } as any;
-
-      jest.spyOn(Reflect, 'getMetadata').mockReturnValue(undefined);
-
-      // Both services process the same class
-      service1.processInstanceMethods(wrapper);
-      service2.processInstanceMethods(wrapper);
-
-      const stats1 = service1.getCacheStats();
-      const stats2 = service2.getCacheStats();
-
-      // Each service should have its own cache miss
-      expect(stats1.misses).toBe(1);
-      expect(stats1.hits).toBe(0);
-      expect(stats2.misses).toBe(1);
-      expect(stats2.hits).toBe(0);
-    });
-
-    it('should maintain cache consistency within same service instance', () => {
-      class TestClass {
-        method1() {}
-      }
-
-      const wrapper = { instance: new TestClass(), metatype: TestClass } as any;
-      jest.spyOn(Reflect, 'getMetadata').mockReturnValue(undefined);
-
-      // First call - cache miss
-      const result1 = service.processInstanceMethods(wrapper);
-      const stats1 = service.getCacheStats();
-
-      // Second call - cache hit
-      const result2 = service.processInstanceMethods(wrapper);
-      const stats2 = service.getCacheStats();
-
-      // Results should be identical (same reference from cache)
-      expect(result1).toBe(result2);
-      expect(stats1.misses).toBe(1);
-      expect(stats1.hits).toBe(0);
-      expect(stats2.misses).toBe(1);
-      expect(stats2.hits).toBe(1);
-    });
-  });
-
-  describe('Cache statistics and monitoring', () => {
-    it('should provide accurate cache hit rate calculation', () => {
-      class TestClass {
-        method1() {}
-      }
-
-      const wrapper = { instance: new TestClass(), metatype: TestClass } as any;
-      jest.spyOn(Reflect, 'getMetadata').mockReturnValue(undefined);
-
-      // Initial state - no operations
-      expect(service.getCacheHitRate()).toBe(0);
-
-      // After first call (miss)
-      service.processInstanceMethods(wrapper);
-      expect(service.getCacheHitRate()).toBe(0);
-
-      // After second call (hit)
-      service.processInstanceMethods(wrapper);
-      expect(service.getCacheHitRate()).toBe(50);
-
-      // After third call (hit)
-      service.processInstanceMethods(wrapper);
-      expect(service.getCacheHitRate()).toBeCloseTo(66.67, 1);
-    });
-
-    it('should track cache statistics correctly across multiple classes', () => {
-      class TestClass1 {
-        method1() {}
-      }
-      class TestClass2 {
-        method1() {}
-      }
-      class TestClass3 {
-        method1() {}
-      }
-
-      const wrappers = [
-        { instance: new TestClass1(), metatype: TestClass1 },
-        { instance: new TestClass2(), metatype: TestClass2 },
-        { instance: new TestClass3(), metatype: TestClass3 },
-      ] as any[];
-
-      jest.spyOn(Reflect, 'getMetadata').mockReturnValue(undefined);
-
-      // First round - all misses
-      wrappers.forEach(wrapper => service.processInstanceMethods(wrapper));
-      let stats = service.getCacheStats();
-      expect(stats.misses).toBe(3);
-      expect(stats.hits).toBe(0);
-
-      // Second round - all hits
-      wrappers.forEach(wrapper => service.processInstanceMethods(wrapper));
-      stats = service.getCacheStats();
-      expect(stats.misses).toBe(3);
-      expect(stats.hits).toBe(3);
-
-      expect(service.getCacheHitRate()).toBe(50);
+      const first = results[0];
+      results.forEach(result => expect(result).toBe(first));
     });
   });
 });

--- a/src/services/method-processor.service.spec.ts
+++ b/src/services/method-processor.service.spec.ts
@@ -239,37 +239,4 @@ describe('MethodProcessor', () => {
       }).toThrow(AOPError);
     });
   });
-
-  describe('getCacheStats', () => {
-    it('should return empty stats when monitoring is disabled', () => {
-      // Create service with NODE_ENV=production to disable stats
-      const originalEnv = process.env.NODE_ENV;
-      process.env.NODE_ENV = 'production';
-
-      const productionService = new MethodProcessor();
-      const stats = productionService.getCacheStats();
-
-      expect(stats).toEqual({
-        hits: 0,
-        misses: 0,
-        enabled: false,
-      });
-
-      process.env.NODE_ENV = originalEnv;
-    });
-  });
-
-  describe('getCacheHitRate', () => {
-    it('should return 0 when stats are disabled', () => {
-      const originalEnv = process.env.NODE_ENV;
-      process.env.NODE_ENV = 'production';
-
-      const productionService = new MethodProcessor();
-      const hitRate = productionService.getCacheHitRate();
-
-      expect(hitRate).toBe(0);
-
-      process.env.NODE_ENV = originalEnv;
-    });
-  });
 });

--- a/src/services/method-processor.service.ts
+++ b/src/services/method-processor.service.ts
@@ -20,20 +20,9 @@ interface MethodCache {
 export class MethodProcessor {
   private classCache = new WeakMap<Function, MethodCache>();
 
-  private readonly enableStats: boolean;
-  private cacheStats = {
-    hits: 0,
-    misses: 0,
-  };
-
-  constructor() {
-    // Disable stats in production for performance
-    this.enableStats = process.env.NODE_ENV !== 'production';
-  }
-
   /**
    * Analyzes a class instance to find all methods that have AOP decorators
-   * applied.
+   * applied. Results are cached per class constructor.
    *
    * @param wrapper - InstanceWrapper containing the instance and metatype
    *
@@ -52,19 +41,11 @@ export class MethodProcessor {
 
     const cached = this.classCache.get(metatype);
     if (cached) {
-      if (this.enableStats) this.cacheStats.hits++;
       return cached;
     }
 
-    // Cache miss: process methods
-    if (this.enableStats) this.cacheStats.misses++;
     const methods = this.processMethodsInternal(metatype);
-
-    const result = {
-      methods,
-      metatype,
-    };
-
+    const result = { methods, metatype };
     this.classCache.set(metatype, result);
 
     return result;
@@ -174,48 +155,5 @@ export class MethodProcessor {
     }
 
     return order;
-  }
-
-  /**
-   * Clears all caches. Useful for testing or when runtime metadata changes are expected.
-   * Note: WeakMap entries will be automatically garbage collected when their keys are no longer referenced.
-   */
-  clearCaches(): void {
-    this.classCache = new WeakMap();
-    if (this.enableStats) {
-      this.cacheStats = { hits: 0, misses: 0 };
-    }
-  }
-
-  /**
-   * Gets cache statistics for monitoring and debugging.
-   *
-   * Returns empty stats if monitoring is disabled.
-   */
-  getCacheStats() {
-    if (!this.enableStats) {
-      return {
-        hits: 0,
-        misses: 0,
-        enabled: false,
-      };
-    }
-
-    return {
-      ...this.cacheStats,
-      enabled: true,
-    };
-  }
-
-  /**
-   * Gets cache hit rate as a percentage.
-   *
-   * @returns Hit rate percentage (0-100) or 0 if stats disabled
-   */
-  getCacheHitRate(): number {
-    if (!this.enableStats) return 0;
-
-    const totalAccess = this.cacheStats.hits + this.cacheStats.misses;
-    return totalAccess > 0 ? (this.cacheStats.hits / totalAccess) * 100 : 0;
   }
 }

--- a/src/services/method-processor.service.ts
+++ b/src/services/method-processor.service.ts
@@ -2,7 +2,11 @@ import { Injectable } from '@nestjs/common';
 import { InstanceWrapper } from '@nestjs/core/injector/instance-wrapper';
 import { AOP_ORDER_METADATA_KEY } from '../decorators';
 import { AOPError } from '../error';
-import type { AOPDecoratorMetadata, AOPMethodWithDecorators } from '../interfaces';
+import type {
+  AOPDecoratorMetadata,
+  AOPDecoratorMetadataWithOrder,
+  AOPMethodWithDecorators,
+} from '../interfaces';
 import { AOP_METADATA_KEY, getAllMethods, resolveMetatype } from '../utils';
 
 interface MethodCache {
@@ -98,18 +102,16 @@ export class MethodProcessor {
   private getDecorators(
     metatype: InstanceWrapper['metatype'],
     methodName: string,
-  ): any[] | undefined {
+  ): AOPDecoratorMetadataWithOrder[] | undefined {
     const decorators = this.getAspectDecorator(metatype, methodName);
     if (!decorators || decorators.length === 0) {
       return undefined;
     }
 
-    const decoratorsWithOrder = decorators.map(decorator => {
+    return decorators.map(decorator => {
       const order = this.getAspectOrderDecorator(decorator);
       return { ...decorator, order };
     });
-
-    return decoratorsWithOrder;
   }
 
   /**


### PR DESCRIPTION
Two small refactors to `MethodProcessor`. No change in observable behavior; full suite (127 tests), lint, and `tsc` build are clean.

## Remove unused cache-statistics tracking

`MethodProcessor` carried a hit/miss statistics API — `getCacheStats`, `getCacheHitRate`, `clearCaches`, and the `enableStats`/`cacheStats` state. The class is internal and not exported from the package entry point, and nothing outside the tests ever read the counters; they only added branches to the caching hot path and state to maintain.

The `WeakMap` cache itself is kept — only the statistics scaffolding is removed. The cache spec is rewritten to assert the actual caching behavior (reference identity on repeated calls, and no reprocessing measured via metadata-read counts) rather than inspecting hit/miss counters, which is closer to what callers actually rely on.

## Type getDecorators return value precisely

`getDecorators` was annotated `any[] | undefined`, discarding the type of the metadata it builds. It now returns `AOPDecoratorMetadataWithOrder[] | undefined`, matching what it actually produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)