### PR TITLE
refactor: drop no-op advice-contract constraints from decorator factories

### DIFF
--- a/src/decorators/aop-decorator-classes.ts
+++ b/src/decorators/aop-decorator-classes.ts
@@ -1,14 +1,9 @@
 import { Injectable } from '@nestjs/common';
 import type {
-  AfterAOP,
-  AfterReturningAOP,
-  AfterThrowingAOP,
   AOPMethod,
   AOPOptions,
   AOPType,
-  AroundAOP,
   AroundAOPContext,
-  BeforeAOP,
   ErrorAOPContext,
   IAOPDecorator,
   ResultAOPContext,
@@ -50,9 +45,9 @@ export type AOPDecoratorConstructor<
  * ```
  */
 @Injectable()
-export abstract class AOPDecorator<Options extends AOPOptions = AOPOptions>
-  implements IAOPDecorator<Options>
-{
+export abstract class AOPDecorator<
+  Options extends AOPOptions = AOPOptions,
+> implements IAOPDecorator<Options> {
   /**
    * Internal helper to add metadata for the decorator.
    *
@@ -129,7 +124,7 @@ export abstract class AOPDecorator<Options extends AOPOptions = AOPOptions>
    * ```
    */
   static around<Options extends AOPOptions = AOPOptions>(
-    this: AOPDecoratorConstructor<Options> & AroundAOP<Options>,
+    this: AOPDecoratorConstructor<Options>,
     options: Options = {} as Options,
   ) {
     return AOPDecorator.addDecoratorMetadata({
@@ -158,7 +153,7 @@ export abstract class AOPDecorator<Options extends AOPOptions = AOPOptions>
    * ```
    */
   static before<Options extends AOPOptions = AOPOptions>(
-    this: AOPDecoratorConstructor<Options> & BeforeAOP<Options>,
+    this: AOPDecoratorConstructor<Options>,
     options: Options = {} as Options,
   ) {
     return AOPDecorator.addDecoratorMetadata({
@@ -188,7 +183,7 @@ export abstract class AOPDecorator<Options extends AOPOptions = AOPOptions>
    * ```
    */
   static after<Options extends AOPOptions = AOPOptions>(
-    this: AOPDecoratorConstructor<Options> & AfterAOP<Options>,
+    this: AOPDecoratorConstructor<Options>,
     options: Options = {} as Options,
   ) {
     return AOPDecorator.addDecoratorMetadata({
@@ -218,7 +213,7 @@ export abstract class AOPDecorator<Options extends AOPOptions = AOPOptions>
    * ```
    */
   static afterReturning<Options extends AOPOptions = AOPOptions>(
-    this: AOPDecoratorConstructor<Options> & AfterReturningAOP<Options, any>,
+    this: AOPDecoratorConstructor<Options>,
     options: Options = {} as Options,
   ) {
     return AOPDecorator.addDecoratorMetadata({
@@ -248,7 +243,7 @@ export abstract class AOPDecorator<Options extends AOPOptions = AOPOptions>
    * ```
    */
   static afterThrowing<Options extends AOPOptions = AOPOptions>(
-    this: AOPDecoratorConstructor<Options> & AfterThrowingAOP<Options, unknown>,
+    this: AOPDecoratorConstructor<Options>,
     options: Options = {} as Options,
   ) {
     return AOPDecorator.addDecoratorMetadata({


### PR DESCRIPTION
## Background

The static decorator factories typed `this` as `AOPDecoratorConstructor<Options> & XxxAOP<Options>` (e.g. `& BeforeAOP<Options>` on `before`). This looked like it restricted a factory to aspects that implement the matching advice — but it enforces nothing.

`AOPDecorator` declares every advice method (`around?`, `before?`, …) as **optional**, so any subclass structurally satisfies each `XxxAOP` contract and the intersection gates nothing. Verified against the real types: an aspect implementing **no** advice still compiles `EmptyAspect.before({})` and `EmptyAspect.around({})`. (Advice-existence checking and partial implementation are fundamentally at odds — optional methods are required for partial implementation, and they defeat the constraint.)

## Change

Drop the dead `& XxxAOP<Options>` intersections, leaving `this: AOPDecoratorConstructor<Options>`, and remove the now-unused advice-contract imports.

## Type inference is unchanged

Options checking comes from the `<Options>` generic and the `options: Options` parameter, not from the constraint. A type probe against the real `AOPDecorator` confirms it still holds after the change:

- `Logging.before<LogOptions>({ level: 'info' })` → ok
- `Logging.before<LogOptions>({ level: 'WRONG' })` → error (TS2322)
- `Logging.after<LogOptions>({ typo: 1 })` → error (TS2353)

127 tests pass, lint and `tsc` build are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)