### PR TITLE
test: clean up low-value tests, enhance e2e, and close coverage gaps

### DIFF
--- a/src/aop.module.spec.ts
+++ b/src/aop.module.spec.ts
@@ -5,6 +5,7 @@ import { AOP_TYPES, AOPDecoratorMetadataWithOrder, AOPMethodWithDecorators } fro
 import { DecoratorApplier } from './services/decorator-applier.service';
 import { InstanceCollector } from './services/instance-collector.service';
 import { MethodProcessor } from './services/method-processor.service';
+import { logger } from './utils';
 
 // Mock the resolveMetatype utility
 jest.mock('./utils/resolve-metatype', () => ({
@@ -85,10 +86,14 @@ describe('AOPModule', () => {
       expect(methodProcessor.processInstanceMethods).toHaveBeenCalledWith(mockWrapper2);
     });
 
-    it('should handle null instances array', () => {
+    it('should log and rethrow when initialization fails', () => {
+      const errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => undefined);
       instanceCollector.collectAllInstances.mockReturnValue(null as any);
 
       expect(() => (aopModule as any).initializeAOP()).toThrow();
+      expect(errorSpy).toHaveBeenCalled();
+
+      errorSpy.mockRestore();
     });
   });
 
@@ -187,6 +192,20 @@ describe('AOPModule', () => {
       (aopModule as any).processInstance(mockWrapper, []);
 
       expect(methodProcessor.processInstanceMethods).toHaveBeenCalledWith(mockWrapper);
+    });
+
+    it('should log and not rethrow when processing one instance fails', () => {
+      const errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => undefined);
+      const mockWrapper = { instance: {}, metatype: class Test {}, name: 'FailWrapper' } as any;
+      methodProcessor.processInstanceMethods.mockImplementation(() => {
+        throw new Error('processing failed');
+      });
+
+      // A single failing instance must not abort the whole AOP initialization.
+      expect(() => (aopModule as any).processInstance(mockWrapper, [])).not.toThrow();
+      expect(errorSpy).toHaveBeenCalled();
+
+      errorSpy.mockRestore();
     });
   });
 
@@ -299,6 +318,35 @@ describe('AOPModule', () => {
         aopDecorators: null,
         originalMethod,
       });
+    });
+
+    it('should log and not rethrow when applying decorators fails', () => {
+      const errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => undefined);
+      class TestDecorator {
+        testMethod() {}
+      }
+      const mockWrapper = { instance: {}, metatype: TestDecorator, name: 'FailWrapper' } as any;
+      const originalMethod = jest.fn();
+      (mockWrapper.metatype.prototype as any).testMethod = originalMethod;
+      decoratorApplier.applyDecorators.mockImplementation(() => {
+        throw new Error('apply failed');
+      });
+
+      // A single failing method must not abort processing of the rest.
+      expect(() =>
+        (aopModule as any).processMethod({
+          wrapper: mockWrapper,
+          methodName: 'testMethod',
+          decorators: [
+            { type: AOP_TYPES.BEFORE, options: {}, decoratorClass: TestDecorator, order: 0 },
+          ],
+          aopDecorators: [],
+          originalMethod,
+        }),
+      ).not.toThrow();
+      expect(errorSpy).toHaveBeenCalled();
+
+      errorSpy.mockRestore();
     });
   });
 

--- a/src/services/instance-collector.service.spec.ts
+++ b/src/services/instance-collector.service.spec.ts
@@ -65,6 +65,18 @@ describe('InstanceCollector', () => {
         mockAOPDecorator.constructor,
       );
     });
+
+    it('should cache the result and not re-scan providers on subsequent calls', () => {
+      Reflect.hasMetadata = jest.fn().mockReturnValue(false);
+      mockDiscoveryService.getProviders.mockReturnValue([{ instance: {} } as any]);
+
+      const first = service.collectAOPDecorators();
+      const second = service.collectAOPDecorators();
+
+      // Same cached array reference, and providers scanned only once.
+      expect(second).toBe(first);
+      expect(mockDiscoveryService.getProviders).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('isAOPDecorator', () => {

--- a/src/services/method-processor.service.spec.ts
+++ b/src/services/method-processor.service.spec.ts
@@ -239,4 +239,16 @@ describe('MethodProcessor', () => {
       }).toThrow(AOPError);
     });
   });
+
+  describe('getAspectDecorator', () => {
+    it('should return undefined when metatype is null', () => {
+      expect((service as any).getAspectDecorator(null, 'testMethod')).toBeUndefined();
+    });
+  });
+
+  describe('processMethodsInternal', () => {
+    it('should return an empty array when the prototype is unavailable', () => {
+      expect((service as any).processMethodsInternal({ prototype: null })).toEqual([]);
+    });
+  });
 });

--- a/src/utils/resolve-metatype.spec.ts
+++ b/src/utils/resolve-metatype.spec.ts
@@ -161,6 +161,14 @@ describe('resolveMetatype', () => {
       const result = resolveMetatype(wrapper);
       expect(result).toBeNull();
     });
+
+    it('should return null for a factory metatype that produced no instance', () => {
+      // Factory function (no class prototype) and nothing to recover from.
+      const wrapper = { metatype: () => undefined, instance: null } as any;
+
+      const result = resolveMetatype(wrapper);
+      expect(result).toBeNull();
+    });
   });
 
   describe('real-world scenarios', () => {

--- a/test/e2e/advice-cycle.e2e-spec.ts
+++ b/test/e2e/advice-cycle.e2e-spec.ts
@@ -1,0 +1,217 @@
+import { Injectable, Module } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  AOPDecorator,
+  AOPMethod,
+  AOPModule,
+  AroundAOPContext,
+  Aspect,
+  ErrorAOPContext,
+  ResultAOPContext,
+} from '../../src';
+
+const trace: string[] = [];
+
+// Records the full advice lifecycle around a method.
+@Aspect()
+class CycleAspect extends AOPDecorator {
+  around({ proceed }: AroundAOPContext): AOPMethod {
+    return (...args: any[]) => {
+      trace.push('around:before');
+      const result = proceed(...args);
+      trace.push('around:after');
+      return result;
+    };
+  }
+  before() {
+    return () => trace.push('before');
+  }
+  after() {
+    return () => trace.push('after');
+  }
+  afterReturning({ result }: ResultAOPContext) {
+    return () => trace.push(`afterReturning:${result}`);
+  }
+  afterThrowing({ error }: ErrorAOPContext<any, Error>) {
+    return () => trace.push(`afterThrowing:${error?.message}`);
+  }
+}
+
+// Around advice that rewrites the incoming arguments and the outgoing result.
+@Aspect()
+class TransformAspect extends AOPDecorator {
+  around({ proceed }: AroundAOPContext): AOPMethod {
+    return (...args: any[]) => {
+      const doubled = args.map((a: number) => a * 2);
+      const result = proceed(...doubled);
+      return result + 100;
+    };
+  }
+}
+
+// Around advice that can skip the method entirely.
+@Aspect()
+class GuardAspect extends AOPDecorator {
+  around({ proceed, options }: AroundAOPContext): AOPMethod {
+    return (...args: any[]) => {
+      if (options.skip) return 'short-circuited';
+      return proceed(...args);
+    };
+  }
+}
+
+@Aspect({ order: 1 })
+class OuterAspect extends AOPDecorator {
+  around({ proceed }: AroundAOPContext): AOPMethod {
+    return (...args: any[]) => {
+      trace.push('outer:before');
+      const result = proceed(...args);
+      trace.push('outer:after');
+      return result;
+    };
+  }
+}
+
+@Aspect({ order: 2 })
+class InnerAspect extends AOPDecorator {
+  around({ proceed }: AroundAOPContext): AOPMethod {
+    return (...args: any[]) => {
+      trace.push('inner:before');
+      const result = proceed(...args);
+      trace.push('inner:after');
+      return result;
+    };
+  }
+}
+
+// A before advice that throws, to observe how a failing advice affects the call.
+@Aspect()
+class ThrowingBeforeAspect extends AOPDecorator {
+  before() {
+    return () => {
+      throw new Error('before-failed');
+    };
+  }
+}
+
+@Injectable()
+class DemoService {
+  @CycleAspect.around()
+  @CycleAspect.before()
+  @CycleAspect.after()
+  @CycleAspect.afterReturning()
+  succeed() {
+    trace.push('method');
+    return 'value';
+  }
+
+  @CycleAspect.around()
+  @CycleAspect.before()
+  @CycleAspect.after()
+  @CycleAspect.afterThrowing()
+  fail() {
+    trace.push('method');
+    throw new Error('boom');
+  }
+
+  @TransformAspect.around()
+  identity(n: number) {
+    return n;
+  }
+
+  ran = false;
+
+  @GuardAspect.around({ skip: true })
+  blocked() {
+    this.ran = true;
+    return 'real';
+  }
+
+  @OuterAspect.around()
+  @InnerAspect.around()
+  nested() {
+    trace.push('method');
+    return 'nested';
+  }
+
+  beforeThrewRan = false;
+
+  @ThrowingBeforeAspect.before()
+  fragile() {
+    this.beforeThrewRan = true;
+    return 'done';
+  }
+}
+
+@Module({
+  imports: [AOPModule],
+  providers: [
+    DemoService,
+    CycleAspect,
+    TransformAspect,
+    GuardAspect,
+    OuterAspect,
+    InnerAspect,
+    ThrowingBeforeAspect,
+  ],
+})
+class DemoModule {}
+
+describe('AOP advice lifecycle (e2e test)', () => {
+  let app: TestingModule;
+  let service: DemoService;
+
+  beforeEach(async () => {
+    trace.length = 0;
+    app = await Test.createTestingModule({ imports: [DemoModule] }).compile();
+    await app.init();
+    service = app.get(DemoService);
+  });
+
+  afterEach(async () => {
+    await app?.close();
+  });
+
+  it('runs the full advice cycle in Spring order on success', () => {
+    const result = service.succeed();
+
+    expect(result).toBe('value');
+    expect(trace).toEqual([
+      'around:before',
+      'before',
+      'method',
+      'afterReturning:value',
+      'after',
+      'around:after',
+    ]);
+  });
+
+  it('runs afterThrowing (not afterReturning) when the method throws', () => {
+    expect(() => service.fail()).toThrow('boom');
+
+    // around:after is never reached because proceed() rethrows.
+    expect(trace).toEqual(['around:before', 'before', 'method', 'afterThrowing:boom', 'after']);
+  });
+
+  it('lets around rewrite both the arguments and the return value', () => {
+    // identity(5): args doubled to 10, method returns 10, around adds 100 => 110
+    expect(service.identity(5)).toBe(110);
+  });
+
+  it('lets around short-circuit the method entirely', () => {
+    expect(service.blocked()).toBe('short-circuited');
+    expect(service.ran).toBe(false);
+  });
+
+  it('nests multiple around advices by ascending order (lower order outermost)', () => {
+    const result = service.nested();
+
+    expect(result).toBe('nested');
+    expect(trace).toEqual(['outer:before', 'inner:before', 'method', 'inner:after', 'outer:after']);
+  });
+
+  it('propagates a throwing before-advice and skips the method', () => {
+    expect(() => service.fragile()).toThrow('before-failed');
+    expect(service.beforeThrewRan).toBe(false);
+  });
+});

--- a/test/e2e/aop-class.e2e-spec.ts
+++ b/test/e2e/aop-class.e2e-spec.ts
@@ -1,58 +1,50 @@
-import { Controller, Get, INestApplication, Injectable, Module } from '@nestjs/common';
+import { INestApplication, Injectable, Module } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import * as request from 'supertest';
 import { AOPDecorator, AOPMethod, AOPModule, AroundAOPContext, Aspect } from '../../src';
 
-class AOPTracker {
-  static count = 0;
-
-  static reset() {
-    this.count = 0;
-  }
-}
+// Records which methods the class-level aspect actually wrapped.
+const wrapped: string[] = [];
 
 @Aspect()
 class TestAOPDecorator extends AOPDecorator {
-  around({ proceed }: AroundAOPContext): AOPMethod {
+  around({ method, proceed }: AroundAOPContext): AOPMethod {
     return (...args: any[]) => {
-      const result = proceed(args);
-      AOPTracker.count += 1;
-      return result;
+      wrapped.push(method.name);
+      return proceed(...args);
     };
   }
 }
 
+// The class-level decorator must apply the around advice to every public method.
 @Injectable()
 @TestAOPDecorator.around()
 class TestService {
-  getHello(name: string) {
+  greet(name: string) {
     return `Hello ${name}!`;
   }
-}
 
-@Controller()
-class TestController {
-  constructor(private readonly testService: TestService) {}
+  add(a: number, b: number) {
+    return a + b;
+  }
 
-  @Get()
-  getHello() {
-    return this.testService.getHello('World');
+  noArgs() {
+    return 'constant';
   }
 }
 
 @Module({
   // To make test faster, we use default AOPModule without forRoot
   imports: [AOPModule],
-  controllers: [TestController],
   providers: [TestService, TestAOPDecorator],
 })
 class TestModule {}
 
-describe('AOP Class in Nest.js (e2e test)', () => {
+describe('Class-level AOP in Nest.js (e2e test)', () => {
   let app: INestApplication;
+  let service: TestService;
 
   beforeEach(async () => {
-    AOPTracker.reset();
+    wrapped.length = 0;
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [TestModule],
@@ -60,15 +52,32 @@ describe('AOP Class in Nest.js (e2e test)', () => {
 
     app = moduleFixture.createNestApplication();
     await app.init();
+    service = app.get(TestService);
   });
 
-  it('/ (GET) - should return hello message with AOP tracking', async () => {
-    return request
-      .default(app.getHttpServer())
-      .get('/')
-      .then(() => {
-        // Check if AOP advice was executed
-        expect(AOPTracker.count).toBeGreaterThan(0);
-      });
+  afterEach(async () => {
+    await app?.close();
+  });
+
+  it('should apply the advice to every public method of the class', () => {
+    service.greet('World');
+    service.add(2, 3);
+    service.noArgs();
+
+    // The around advice wrapped all three methods.
+    expect(wrapped).toEqual(['greet', 'add', 'noArgs']);
+  });
+
+  it('should preserve arguments and return values through the wrapper', () => {
+    expect(service.greet('World')).toBe('Hello World!');
+    expect(service.add(2, 3)).toBe(5);
+    expect(service.noArgs()).toBe('constant');
+  });
+
+  it('should run the advice once per call', () => {
+    service.greet('A');
+    service.greet('B');
+
+    expect(wrapped).toEqual(['greet', 'greet']);
   });
 });

--- a/test/e2e/aop.e2e-spec.ts
+++ b/test/e2e/aop.e2e-spec.ts
@@ -73,14 +73,10 @@ class TestableAOP extends AOPDecorator<ExampleOptions> {
 // AOP without order (should use default order)
 @Aspect()
 class NoOrderAOP extends AOPDecorator {
-  before({ method }: UnitAOPContext) {
+  before(_: UnitAOPContext) {
     return (...args: any[]) => {
       AOPTracker.beforeCount++;
       AOPTracker.lastArgs = args;
-      // For NoOrderAOP, we'll simulate setting the result
-      if (method.name === 'getNoOrder') {
-        AOPTracker.lastResult = 'No order test';
-      }
     };
   }
 }
@@ -399,10 +395,10 @@ describe('AOP in Nest.js (e2e test)', () => {
     return request
       .default(app.getHttpServer())
       .get('/no-order')
-      .then(() => {
-        // Check if AOP without explicit order works
+      .then(response => {
+        // The before advice ran, and the method returned its real value.
         expect(AOPTracker.beforeCount).toBeGreaterThan(0);
-        expect(AOPTracker.lastResult).toBe('No order test');
+        expect(response.text).toBe('No order test');
       });
   });
 

--- a/test/e2e/async-aop.e2e-spec.ts
+++ b/test/e2e/async-aop.e2e-spec.ts
@@ -73,8 +73,6 @@ describe('AOP advice timing on async methods', () => {
     const result = await service.getAsyncValue();
     expect(result).toBe('async-result');
 
-    console.log('[fulfilled case execution order]', trace);
-
     // Expectation: afterReturning is called with the actual resolved value
     // only after the method has fully completed
     const arIndex = trace.findIndex(t => t.startsWith('afterReturning'));
@@ -85,8 +83,6 @@ describe('AOP advice timing on async methods', () => {
 
   it('afterThrowing should be called when an async method rejects', async () => {
     await expect(service.throwAsync()).rejects.toThrow('async error');
-
-    console.log('[rejected case execution order]', trace);
 
     expect(trace.some(t => t.startsWith('afterThrowing'))).toBe(true);
   });

--- a/test/e2e/factory-provider-aop.e2e-spec.ts
+++ b/test/e2e/factory-provider-aop.e2e-spec.ts
@@ -42,8 +42,6 @@ class SimpleService {
 
   @LoggingAspect.before()
   getName(): string {
-    console.log('[getName] this:', this);
-    console.log('[getName] this.name:', this.name);
     return `Hello ${this.name}`;
   }
 
@@ -182,14 +180,7 @@ describe('Factory Provider AOP Integration (e2e)', () => {
           LoggingAspect,
           {
             provide: SimpleService,
-            useFactory: () => {
-              console.log('[Factory] Creating instance with "factory-created"');
-              const instance = new SimpleService('factory-created');
-              console.log('[Factory] Instance created:', instance);
-              console.log('[Factory] Instance constructor name:', instance.constructor.name);
-              console.log('[Factory] Instance getName method:', typeof instance.getName);
-              return instance;
-            },
+            useFactory: () => new SimpleService('factory-created'),
           },
         ],
       })
@@ -202,14 +193,7 @@ describe('Factory Provider AOP Integration (e2e)', () => {
       await app.init();
 
       const service = app.get<SimpleService>(SimpleService);
-      console.log('[Factory] Retrieved service:', service);
-      console.log('[Factory] Service constructor name:', service.constructor.name);
-      console.log('[Factory] Service getName method:', typeof service.getName);
-
       const result = service.getName();
-
-      console.log('[Factory] Result:', result);
-      console.log('[Factory] CallLog:', callLog);
 
       expect(result).toBe('Hello factory-created');
       expect(callLog).toContain('BEFORE:getName:[]');
@@ -236,9 +220,6 @@ describe('Factory Provider AOP Integration (e2e)', () => {
 
       const service = app.get<SimpleService>(SimpleService);
       const result = service.getPlainName();
-
-      console.log('[Plain] Result:', result);
-      console.log('[Plain] CallLog:', callLog);
 
       expect(result).toBe('Plain factory-test');
       expect(callLog).toEqual([]); // No AOP interception
@@ -385,11 +366,7 @@ describe('Factory Provider AOP Integration (e2e)', () => {
           LoggingAspect,
           {
             provide: 'MULTI_SERVICE',
-            useFactory: (): MultiTypeService => {
-              // Factory can have complex logic
-              const condition = Math.random() > -1; // Always true
-              return condition ? new MultiTypeService() : new MultiTypeService();
-            },
+            useFactory: (): MultiTypeService => new MultiTypeService(),
           },
         ],
       }).compile();


### PR DESCRIPTION
Three-part pass over the test suite: remove meaningless tests, add behavioral e2e coverage for the harder advice paths, and close the remaining coverage gaps. 141 tests pass, lint and build clean. Statements/functions/lines coverage at 100%, branch at 98% (up from ~96%).

## 1. Remove low-value noise / strengthen weak assertions

- **factory-provider e2e**: drop the debugging `console.log` calls and the no-op `Math.random() > -1` / `cond ? new X() : new X()` factory.
- **aop-class e2e**: it only asserted a call counter was `> 0`. Rewritten to verify the class-level `@Aspect` wraps **every** public method and that arguments and return values pass through unchanged.
- **aop e2e**: the no-order case faked the result inside the `before` advice and then asserted the fake. Now asserts the real HTTP response.
- **async-aop e2e**: drop leftover `console.log` trace dumps.

## 2. Enhance e2e (behavioral gaps)

New `advice-cycle.e2e-spec.ts` covering behaviors no test exercised before:

- full Spring cycle order on success (`around-before → before → method → afterReturning → after → around-after`) and on failure (`afterThrowing → after`, `around-after` skipped);
- `around` rewriting both incoming arguments and the outgoing result;
- `around` short-circuiting the method without calling `proceed`;
- multiple `around` advices nesting by ascending order (lower outermost);
- a throwing `before`-advice propagating and skipping the method.

## 3. Close coverage gaps (unit)

- `AOPModule` logs and continues when one instance/method fails, and logs+rethrows when initialization itself fails (these tests also silence the stray error output those paths used to print).
- `InstanceCollector` caches discovered aspects and does not re-scan providers.
- `resolveMetatype` returns null for a factory metatype that produced no instance.
- `MethodProcessor` guards a null metatype and an unavailable prototype.

The few remaining uncovered branches are defensive log-message fallbacks (`wrapper?.name || 'unknown'`) — intentionally not asserted to avoid meaningless tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)