### PR TITLE
chore(release): 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [0.5.0] - 2026.05.31
+
+### Fixed
+
+* Async methods now run `afterReturning` / `afterThrowing` / `after` correctly: the advice waits for the returned promise to settle, so `afterReturning` receives the resolved value and `afterThrowing` catches rejections by @miinhho in https://github.com/miinhho/nestjs-saop/pull/53
+* Method discovery no longer invokes getters while scanning a class, and the decorator metadata cache is no longer mutated while sorting by order by @miinhho in https://github.com/miinhho/nestjs-saop/pull/54
+
+### Changed
+
+* Resolve each advice instance once at startup instead of on every method call, removing the per-invocation lookup from the hot path by @miinhho in https://github.com/miinhho/nestjs-saop/pull/55
+* Remove the unused internal cache-statistics API (`getCacheStats` / `getCacheHitRate` / `clearCaches`) from `MethodProcessor` by @miinhho in https://github.com/miinhho/nestjs-saop/pull/56
+* Simplify the static decorator factory type signatures; option type-checking is unchanged by @miinhho in https://github.com/miinhho/nestjs-saop/pull/57
+
+### Chore
+
+* Update dependencies to clear all security advisories by @miinhho in https://github.com/miinhho/nestjs-saop/pull/58
+* Remove low-value tests, add e2e coverage for the full advice lifecycle, and close coverage gaps by @miinhho in https://github.com/miinhho/nestjs-saop/pull/59
+
+**Full Changelog**: https://github.com/miinhho/nestjs-saop/compare/v0.4.1...v0.5.0
+
 ## [0.4.1] - 2025.12.03
 
 ### What's Changed

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,4 +1,4 @@
-# nestjs-saop v0.4.1
+# nestjs-saop v0.5.0
 
 ## Classes
 

--- a/docs/api/classes/AOPDecorator.md
+++ b/docs/api/classes/AOPDecorator.md
@@ -202,7 +202,7 @@ A callback function executed before the method
 ### after()
 
 ```ts
-static after<Options>(this, options): ClassDecorator & MethodDecorator;
+static after<Options>(this, options?): ClassDecorator & MethodDecorator;
 ```
 
 Creates a decorator that applies after advice to the target.
@@ -220,9 +220,9 @@ it succeeded or threw an exception.
 
 ##### this
 
-`AOPDecoratorConstructor`\<`Options`, `any`[]\> & [`AfterAOP`](../interfaces/AfterAOP.md)\<`Options`\>
+`AOPDecoratorConstructor`\<`Options`\>
 
-##### options
+##### options?
 
 `Options` = `...`
 
@@ -250,7 +250,7 @@ getHello(name: string): string {
 ### afterReturning()
 
 ```ts
-static afterReturning<Options>(this, options): ClassDecorator & MethodDecorator;
+static afterReturning<Options>(this, options?): ClassDecorator & MethodDecorator;
 ```
 
 Creates a decorator that applies after-returning advice to the target.
@@ -268,9 +268,9 @@ and provides access to the return value for post-processing.
 
 ##### this
 
-`AOPDecoratorConstructor`\<`Options`, `any`[]\> & [`AfterReturningAOP`](../interfaces/AfterReturningAOP.md)\<`Options`, `any`\>
+`AOPDecoratorConstructor`\<`Options`\>
 
-##### options
+##### options?
 
 `Options` = `...`
 
@@ -298,7 +298,7 @@ getHello(name: string): string {
 ### afterThrowing()
 
 ```ts
-static afterThrowing<Options>(this, options): ClassDecorator & MethodDecorator;
+static afterThrowing<Options>(this, options?): ClassDecorator & MethodDecorator;
 ```
 
 Creates a decorator that applies after-throwing advice to the target.
@@ -316,9 +316,9 @@ and provides access to the error for logging, recovery, or re-throwing.
 
 ##### this
 
-`AOPDecoratorConstructor`\<`Options`, `any`[]\> & [`AfterThrowingAOP`](../interfaces/AfterThrowingAOP.md)\<`Options`, `unknown`\>
+`AOPDecoratorConstructor`\<`Options`\>
 
-##### options
+##### options?
 
 `Options` = `...`
 
@@ -346,7 +346,7 @@ getError(): string {
 ### around()
 
 ```ts
-static around<Options>(this, options): ClassDecorator & MethodDecorator;
+static around<Options>(this, options?): ClassDecorator & MethodDecorator;
 ```
 
 Creates a decorator that applies around advice to the target.
@@ -364,9 +364,9 @@ parameters, conditionally execute the method, or return a different result.
 
 ##### this
 
-`AOPDecoratorConstructor`\<`Options`, `any`[]\> & [`AroundAOP`](../interfaces/AroundAOP.md)\<`Options`, `any`\>
+`AOPDecoratorConstructor`\<`Options`\>
 
-##### options
+##### options?
 
 `Options` = `...`
 
@@ -394,7 +394,7 @@ getHello(name: string): string {
 ### before()
 
 ```ts
-static before<Options>(this, options): ClassDecorator & MethodDecorator;
+static before<Options>(this, options?): ClassDecorator & MethodDecorator;
 ```
 
 Creates a decorator that applies before advice to the target.
@@ -411,9 +411,9 @@ The before advice executes before the method runs.
 
 ##### this
 
-`AOPDecoratorConstructor`\<`Options`, `any`[]\> & [`BeforeAOP`](../interfaces/BeforeAOP.md)\<`Options`\>
+`AOPDecoratorConstructor`\<`Options`\>
 
-##### options
+##### options?
 
 `Options` = `...`
 

--- a/docs/api/classes/AOPError.md
+++ b/docs/api/classes/AOPError.md
@@ -63,7 +63,7 @@ Error.name
 ### stack?
 
 ```ts
-optional stack: string;
+optional stack?: string;
 ```
 
 #### Inherited from

--- a/docs/api/functions/Aspect.md
+++ b/docs/api/functions/Aspect.md
@@ -1,7 +1,7 @@
 # Function: Aspect()
 
 ```ts
-function Aspect(order): ClassDecorator;
+function Aspect(order?): ClassDecorator;
 ```
 
 Class decorator to mark a class as AOP decorator
@@ -11,7 +11,7 @@ services and can be used to apply cross-cutting concerns to methods.
 
 ## Parameters
 
-### order
+### order?
 
 `AspectOptions` = `{}`
 

--- a/docs/api/interfaces/AfterAOP.md
+++ b/docs/api/interfaces/AfterAOP.md
@@ -19,7 +19,7 @@ after(context): AOPMethod<void>;
 
 After decorator method
 
-See [AOPDecorator.after](../classes/AOPDecorator.md#after-2) for details.
+See [AOPDecorator.after](../classes/AOPDecorator.md#after-1) for details.
 
 #### Parameters
 

--- a/docs/api/interfaces/AfterReturningAOP.md
+++ b/docs/api/interfaces/AfterReturningAOP.md
@@ -25,7 +25,7 @@ afterReturning(context): AOPMethod<void>;
 
 AfterReturning decorator method
 
-See [AOPDecorator.afterReturning](../classes/AOPDecorator.md#afterreturning-2) for details.
+See [AOPDecorator.afterReturning](../classes/AOPDecorator.md#afterreturning-1) for details.
 
 #### Parameters
 

--- a/docs/api/interfaces/AfterThrowingAOP.md
+++ b/docs/api/interfaces/AfterThrowingAOP.md
@@ -23,7 +23,7 @@ afterThrowing(context): AOPMethod<void>;
 
 AfterThrowing decorator method
 
-See [AOPDecorator.afterThrowing](../classes/AOPDecorator.md#afterthrowing-2) for details.
+See [AOPDecorator.afterThrowing](../classes/AOPDecorator.md#afterthrowing-1) for details.
 
 #### Parameters
 

--- a/docs/api/interfaces/AroundAOP.md
+++ b/docs/api/interfaces/AroundAOP.md
@@ -25,7 +25,7 @@ around(context): AOPMethod<ReturnType>;
 
 Around decorator method
 
-See [AOPDecorator.around](../classes/AOPDecorator.md#around-2) for details.
+See [AOPDecorator.around](../classes/AOPDecorator.md#around-1) for details.
 
 #### Parameters
 

--- a/docs/api/interfaces/BeforeAOP.md
+++ b/docs/api/interfaces/BeforeAOP.md
@@ -18,7 +18,7 @@ before(context): AOPMethod<void>;
 
 Before decorator method
 
-See [AOPDecorator.before](../classes/AOPDecorator.md#before-2) for details.
+See [AOPDecorator.before](../classes/AOPDecorator.md#before-1) for details.
 
 #### Parameters
 

--- a/docs/api/interfaces/IAOPDecorator.md
+++ b/docs/api/interfaces/IAOPDecorator.md
@@ -23,15 +23,15 @@ for various AOP advice types (around, before, after, etc.).
 
 ## Properties
 
-### after()?
+### after?
 
 ```ts
-optional after: (context) => AOPMethod<void>;
+optional after?: (context) => AOPMethod<void>;
 ```
 
 After decorator method
 
-See [AOPDecorator.after](../classes/AOPDecorator.md#after-2) for details.
+See [AOPDecorator.after](../classes/AOPDecorator.md#after-1) for details.
 
 #### Parameters
 
@@ -45,19 +45,21 @@ See [AOPDecorator.after](../classes/AOPDecorator.md#after-2) for details.
 
 #### Inherited from
 
-[`after`](#after).`__type`
+```ts
+Partial.after
+```
 
 ***
 
-### afterReturning()?
+### afterReturning?
 
 ```ts
-optional afterReturning: (context) => AOPMethod<void>;
+optional afterReturning?: (context) => AOPMethod<void>;
 ```
 
 AfterReturning decorator method
 
-See [AOPDecorator.afterReturning](../classes/AOPDecorator.md#afterreturning-2) for details.
+See [AOPDecorator.afterReturning](../classes/AOPDecorator.md#afterreturning-1) for details.
 
 #### Parameters
 
@@ -71,19 +73,21 @@ See [AOPDecorator.afterReturning](../classes/AOPDecorator.md#afterreturning-2) f
 
 #### Inherited from
 
-[`afterReturning`](#afterreturning).`__type`
+```ts
+Partial.afterReturning
+```
 
 ***
 
-### afterThrowing()?
+### afterThrowing?
 
 ```ts
-optional afterThrowing: (context) => AOPMethod<void>;
+optional afterThrowing?: (context) => AOPMethod<void>;
 ```
 
 AfterThrowing decorator method
 
-See [AOPDecorator.afterThrowing](../classes/AOPDecorator.md#afterthrowing-2) for details.
+See [AOPDecorator.afterThrowing](../classes/AOPDecorator.md#afterthrowing-1) for details.
 
 #### Parameters
 
@@ -97,19 +101,21 @@ See [AOPDecorator.afterThrowing](../classes/AOPDecorator.md#afterthrowing-2) for
 
 #### Inherited from
 
-[`afterThrowing`](#afterthrowing).`__type`
+```ts
+Partial.afterThrowing
+```
 
 ***
 
-### around()?
+### around?
 
 ```ts
-optional around: (context) => AOPMethod<ReturnType>;
+optional around?: (context) => AOPMethod<ReturnType>;
 ```
 
 Around decorator method
 
-See [AOPDecorator.around](../classes/AOPDecorator.md#around-2) for details.
+See [AOPDecorator.around](../classes/AOPDecorator.md#around-1) for details.
 
 #### Parameters
 
@@ -123,19 +129,21 @@ See [AOPDecorator.around](../classes/AOPDecorator.md#around-2) for details.
 
 #### Inherited from
 
-[`around`](#around).`__type`
+```ts
+Partial.around
+```
 
 ***
 
-### before()?
+### before?
 
 ```ts
-optional before: (context) => AOPMethod<void>;
+optional before?: (context) => AOPMethod<void>;
 ```
 
 Before decorator method
 
-See [AOPDecorator.before](../classes/AOPDecorator.md#before-2) for details.
+See [AOPDecorator.before](../classes/AOPDecorator.md#before-1) for details.
 
 #### Parameters
 
@@ -149,4 +157,6 @@ See [AOPDecorator.before](../classes/AOPDecorator.md#before-2) for details.
 
 #### Inherited from
 
-[`before`](#before).`__type`
+```ts
+Partial.before
+```

--- a/docs/api/type-aliases/AOPMethod.md
+++ b/docs/api/type-aliases/AOPMethod.md
@@ -1,4 +1,4 @@
-# Type Alias: AOPMethod()\<ReturnType\>
+# Type Alias: AOPMethod\<ReturnType\>
 
 ```ts
 type AOPMethod<ReturnType> = (...args) => ReturnType;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-saop",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Spring style AOP in Nest.js",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Release 0.5.0.

- Bump `package.json` version `0.4.1` → `0.5.0`
- Add the `0.5.0` entry to `CHANGELOG.md`
- Regenerate the TypeDoc API reference (`pnpm run typedoc`), which now carries `v0.5.0` and reflects the simplified static decorator factory signatures

## 0.5.0 highlights

**Fixed**
- Async methods run `afterReturning` / `afterThrowing` / `after` correctly — the advice waits for the returned promise to settle (#53)
- Method discovery no longer invokes getters, and the decorator metadata cache is no longer mutated while sorting (#54)

**Changed**
- Advice instances are resolved once at startup instead of on every call (#55)
- Removed the unused internal cache-statistics API from `MethodProcessor` (#56)
- Simplified the static decorator factory type signatures; option type-checking is unchanged (#57)

**Chore**
- Dependency updates clearing all security advisories (#58)
- Test cleanup, e2e lifecycle coverage, and coverage-gap closure (#59)

**Full Changelog**: https://github.com/miinhho/nestjs-saop/compare/v0.4.1...v0.5.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)