### PR TITLE
ci: update setup-node and pnpm/action-setup to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,12 +36,12 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4.1.0
+        uses: pnpm/action-setup@v6.0.8
         with:
-          version: ^10.15.0
+          version: ^10.27.0
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4.4.0
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,12 +18,12 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6.0.8
         with:
           version: ^10.27.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4.4.0
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: 24.x
           cache: 'pnpm'


### PR DESCRIPTION
Bring the GitHub Actions up to date and make the pins consistent.

## Changes (ci.yml + release.yml)

- `actions/setup-node` `v4.4.0` → `v6.4.0`
- `pnpm/action-setup` `v4.1.0` / `v4` → `v6.0.8`
- align the pnpm `version` input to `^10.27.0` in both workflows

## Why it's safe

The workflows only use setup-node's `node-version` and `cache: 'pnpm'` inputs, which are unchanged across v4 → v6.

The breaking changes in these majors are about **automatic** package-manager caching, which this repo does not rely on — caching is requested explicitly (`cache: 'pnpm'`) and there is no `packageManager` field in `package.json`.

pnpm stays on 10.x: the `version` input is pinned to `^10.27.0`, so `pnpm/action-setup` v6's default of pnpm 11 does not take effect. The node24 action runtime (setup-node v5+/action-setup v5+) is satisfied by `ubuntu-latest`.

CI validates this PR directly. `release.yml` only runs on tag push, so its update is exercised at the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)