### PR TITLE
chore(example): bump nestjs-saop to ^0.5.0

### DIFF
--- a/example/logging-aop/package.json
+++ b/example/logging-aop/package.json
@@ -23,7 +23,7 @@
     "@nestjs/common": "^11.1.24",
     "@nestjs/core": "^11.1.24",
     "@nestjs/platform-express": "^11.1.24",
-    "nestjs-saop": "^0.4.1",
+    "nestjs-saop": "^0.5.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2"
   },

--- a/example/logging-aop/pnpm-lock.yaml
+++ b/example/logging-aop/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^11.1.24
         version: 11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24)
       nestjs-saop:
-        specifier: ^0.4.1
-        version: 0.4.1(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        specifier: ^0.5.0
+        version: 0.5.0(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -2760,8 +2760,8 @@ packages:
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
-  nestjs-saop@0.4.1:
-    resolution: {integrity: sha512-UkgwWuX93Y99euR4oY9he/SLCVQXCLzZj5E6HmoeTzoURJecp8YyUWT7usoeI6QmuXQ9FQVtjLKWwlR0v1PM7Q==}
+  nestjs-saop@0.5.0:
+    resolution: {integrity: sha512-1X0CQnmZHvQWXo2yLBZ2QByQhORfnVTlEvEga03A4XmgjhC8ULjNdB5PWihdPWzXI6TWscBkyUZPE3hpNY/vSw==}
     peerDependencies:
       '@nestjs/common': ^9 || ^10 || ^11
       '@nestjs/core': ^9 || ^10 || ^11
@@ -6606,7 +6606,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  nestjs-saop@0.4.1(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24)(reflect-metadata@0.2.2)(rxjs@7.8.2):
+  nestjs-saop@0.5.0(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24)(reflect-metadata@0.2.2)(rxjs@7.8.2):
     dependencies:
       '@nestjs/common': 11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.24)(reflect-metadata@0.2.2)(rxjs@7.8.2)


### PR DESCRIPTION
Update the `logging-aop` example to use the freshly published `nestjs-saop@0.5.0`.

- `dependencies.nestjs-saop` `^0.4.1` → `^0.5.0` (the caret on a 0.x version excluded 0.5.0, so this was needed to pick it up)
- refresh `example/logging-aop/pnpm-lock.yaml` (resolves to `nestjs-saop@0.5.0`)

`nest build` passes against 0.5.0; the public API is unchanged in this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)